### PR TITLE
Normalized all files with `ontotools 0.6.2`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-https://github.com/ternaustralia/ontotools/archive/refs/tags/0.3.2.zip
+https://github.com/ternaustralia/ontotools/archive/refs/tags/0.6.2.zip
 pyshacl
 watchdog[watchmedo]
 pytest

--- a/shapes/_meta/meta.shapes.ttl
+++ b/shapes/_meta/meta.shapes.ttl
@@ -1,8 +1,9 @@
-
 PREFIX dcterms: <http://purl.org/dc/terms/>
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX reg: <http://purl.org/linked-data/registry#>
 PREFIX sh: <http://www.w3.org/ns/shacl#>
+PREFIX urnc: <urn:class:>
+PREFIX urnp: <urn:property:>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <urn:shapes:meta:controlled:query>
@@ -11,8 +12,8 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     sh:maxCount 1 ;
     sh:message "An instance of urn:class:Controlled must have a value for urn:property:query." ;
     sh:minCount 1 ;
-    sh:path <urn:property:query> ;
-    sh:targetClass <urn:class:Controlled> ;
+    sh:path urnp:query ;
+    sh:targetClass urnc:Controlled ;
 .
 
 <urn:shapes:meta:requirement:description>
@@ -22,7 +23,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     sh:message "An instance of urn:class:Requirement must have a value for sh:description." ;
     sh:minCount 1 ;
     sh:path sh:description ;
-    sh:targetClass <urn:class:Requirement> ;
+    sh:targetClass urnc:Requirement ;
 .
 
 <urn:shapes:meta:requirement:examples>
@@ -31,8 +32,8 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     sh:message "An instance of urn:class:Requirement must have a value for urn:property:examples" ;
     sh:minCount 1 ;
     sh:nodeKind sh:BlankNodeOrIRI ;
-    sh:path <urn:property:examples> ;
-    sh:targetClass <urn:class:Requirement> ;
+    sh:path urnp:examples ;
+    sh:targetClass urnc:Requirement ;
 .
 
 <urn:shapes:meta:requirement:invalidExample>
@@ -41,8 +42,8 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     sh:maxCount 1 ;
     sh:message "The value node of urn:property:examples must have a value for urn:property:invalidExample." ;
     sh:minCount 1 ;
-    sh:path <urn:property:invalidExample> ;
-    sh:targetObjectsOf <urn:property:examples> ;
+    sh:path urnp:invalidExample ;
+    sh:targetObjectsOf urnp:examples ;
 .
 
 <urn:shapes:meta:requirement:message>
@@ -52,7 +53,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     sh:message "An instance of urn:class:Requirement must have a value for sh:message." ;
     sh:minCount 1 ;
     sh:path sh:message ;
-    sh:targetClass <urn:class:Requirement> ;
+    sh:targetClass urnc:Requirement ;
 .
 
 <urn:shapes:meta:requirement:name>
@@ -62,7 +63,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     sh:message "An instance of urn:class:Requirement must have a value for sh:name." ;
     sh:minCount 1 ;
     sh:path sh:name ;
-    sh:targetClass <urn:class:Requirement> ;
+    sh:targetClass urnc:Requirement ;
 .
 
 <urn:shapes:meta:requirement:rdf-type>
@@ -70,12 +71,12 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     sh:in (
             sh:PropertyShape
             sh:NodeShape
-            <urn:class:Requirement>
-            <urn:class:Controlled>
+            urnc:Requirement
+            urnc:Controlled
         ) ;
     sh:message "An instance of urn:class:Requirement must only be instances of other classes specified in the controlled list." ;
     sh:path rdf:type ;
-    sh:targetClass <urn:class:Requirement> ;
+    sh:targetClass urnc:Requirement ;
 .
 
 <urn:shapes:meta:requirement:source>
@@ -85,7 +86,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     sh:message "An instance of urn:class:Requirement must have a value for dcterms:source." ;
     sh:minCount 1 ;
     sh:path dcterms:source ;
-    sh:targetClass <urn:class:Requirement> ;
+    sh:targetClass urnc:Requirement ;
 .
 
 <urn:shapes:meta:requirement:status>
@@ -99,7 +100,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     sh:message "An instance of urn:class:Requirement must have a value for reg:status." ;
     sh:minCount 1 ;
     sh:path reg:status ;
-    sh:targetClass <urn:class:Requirement> ;
+    sh:targetClass urnc:Requirement ;
 .
 
 <urn:shapes:meta:requirement:validExample>
@@ -108,8 +109,8 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     sh:maxCount 1 ;
     sh:message "The value node of urn:property:examples must have a value for urn:property:validExample." ;
     sh:minCount 1 ;
-    sh:path <urn:property:validExample> ;
-    sh:targetObjectsOf <urn:property:examples> ;
+    sh:path urnp:validExample ;
+    sh:targetObjectsOf urnp:examples ;
 .
 
 <urn:shapes:meta:requirement:validator>
@@ -118,7 +119,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     sh:maxCount 1 ;
     sh:message "An instance of urn:class:Requirement must have exactly 1 xsd:anyURI value for urn:property:validator." ;
     sh:minCount 1 ;
-    sh:path <urn:property:validator> ;
-    sh:targetClass <urn:class:Requirement> ;
+    sh:path urnp:validator ;
+    sh:targetClass urnc:Requirement ;
 .
 

--- a/shapes/plot-description/aspect/invalid.ttl
+++ b/shapes/plot-description/aspect/invalid.ttl
@@ -1,4 +1,3 @@
-
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX sosa: <http://www.w3.org/ns/sosa/>

--- a/shapes/plot-description/aspect/shapes.ttl
+++ b/shapes/plot-description/aspect/shapes.ttl
@@ -1,17 +1,17 @@
-
 PREFIX dcterms: <http://purl.org/dc/terms/>
-PREFIX ns1: <urn:property:>
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX reg: <http://purl.org/linked-data/registry#>
 PREFIX sh: <http://www.w3.org/ns/shacl#>
 PREFIX sosa: <http://www.w3.org/ns/sosa/>
 PREFIX tern: <https://w3id.org/tern/ontologies/tern/>
+PREFIX urnc: <urn:class:>
+PREFIX urnp: <urn:property:>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <urn:shapes:plot-description:aspect:feature-type>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "TERN's ecologists have determined the feature type is _landform_, defined by the link:https://www.publish.csiro.au/book/5230/[Australian Soil and Land Survey Field Handbook]." ;
@@ -32,17 +32,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/aspect/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/aspect/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/aspect/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/aspect/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/aspect/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/aspect/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:aspect:simple-result>
     a
         sh:NodeShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "Value of `sosa:hasSimpleResult` _MUST_ be the same as the value in `sosa:hasResult`." ;
@@ -65,17 +65,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     """
         ] ;
     sh:targetClass tern:Observation ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/aspect/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/aspect/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/aspect/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/aspect/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/aspect/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/aspect/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:aspect:site-visit>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "Observations following the Plot Description protocol are made in the context of a site visit." ;
@@ -97,17 +97,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/aspect/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/aspect/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/aspect/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/aspect/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/aspect/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/aspect/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:aspect:unit-of-measure>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "Result value's unit of measure _MUST_ have the value `unit:DEG`." ;
@@ -128,17 +128,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/aspect/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/aspect/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/aspect/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/aspect/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/aspect/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/aspect/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:aspect:used-procedure>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description """IRI of procedure _MUST_ have the value `https://linked.data.gov.au/def/test/dawe-cv/1ff9e97c-3bdd-44c9-bdd3-401fa31c0b32`.
@@ -160,17 +160,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/aspect/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/aspect/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/aspect/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/aspect/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/aspect/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/aspect/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:aspect:value-range>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "Value _MUST_ be between 0 exclusive and 360 inclusive." ;
@@ -192,17 +192,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/aspect/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/aspect/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/aspect/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/aspect/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/aspect/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/aspect/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:aspect:value-type>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:class tern:Float ;
@@ -222,10 +222,10 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/aspect/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/aspect/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/aspect/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/aspect/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/aspect/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/aspect/shapes.ttl"^^xsd:anyURI ;
 .
 

--- a/shapes/plot-description/aspect/valid.ttl
+++ b/shapes/plot-description/aspect/valid.ttl
@@ -1,4 +1,3 @@
-
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX sosa: <http://www.w3.org/ns/sosa/>

--- a/shapes/plot-description/climatic-condition/invalid.ttl
+++ b/shapes/plot-description/climatic-condition/invalid.ttl
@@ -1,4 +1,3 @@
-
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX sosa: <http://www.w3.org/ns/sosa/>

--- a/shapes/plot-description/climatic-condition/shapes.ttl
+++ b/shapes/plot-description/climatic-condition/shapes.ttl
@@ -1,17 +1,17 @@
-
 PREFIX dcterms: <http://purl.org/dc/terms/>
-PREFIX ns1: <urn:property:>
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX reg: <http://purl.org/linked-data/registry#>
 PREFIX sh: <http://www.w3.org/ns/shacl#>
 PREFIX sosa: <http://www.w3.org/ns/sosa/>
 PREFIX tern: <https://w3id.org/tern/ontologies/tern/>
+PREFIX urnc: <urn:class:>
+PREFIX urnp: <urn:property:>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <urn:shapes:plot-description:climatic-condition:feature-type>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "TERN's ecologists have determined the feature type is _climate_, defined by the link:https://www.publish.csiro.au/book/5230/[Australian Soil and Land Survey Field Handbook]." ;
@@ -32,18 +32,18 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/climatic-condition/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/climatic-condition/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/climatic-condition/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/climatic-condition/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/climatic-condition/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/climatic-condition/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:climatic-condition:result-value>
     a
         sh:PropertyShape ,
-        <urn:class:Controlled> ,
-        <urn:class:Requirement> ;
+        urnc:Controlled ,
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "The value in `sosa:hasResult` _MUST_ be a value in `sh:in`, which is the Climatic condition codes controlled vocabulary." ;
@@ -67,11 +67,11 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/climatic-condition/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/climatic-condition/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/climatic-condition/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/climatic-condition/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:query """
+    urnp:query """
             PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
             select ?values {
                     ?s skos:member ?values .
@@ -79,14 +79,14 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             }
 
     """ ;
-    ns1:sparqlEndpoint "https://graphdb.tern.org.au/repositories/dawe_vocabs_core" ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/climatic-condition/shapes.ttl"^^xsd:anyURI ;
+    urnp:sparqlEndpoint "https://graphdb.tern.org.au/repositories/dawe_vocabs_core" ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/climatic-condition/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:climatic-condition:simple-result>
     a
         sh:NodeShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "Value of `sosa:hasSimpleResult` _MUST_ be the same as the value in `sosa:hasResult`." ;
@@ -109,17 +109,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     """
         ] ;
     sh:targetClass tern:Observation ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/climatic-condition/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/climatic-condition/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/climatic-condition/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/climatic-condition/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/climatic-condition/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/climatic-condition/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:climatic-condition:site-visit>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "Observations following the Plot Description protocol are made in the context of a site visit." ;
@@ -141,17 +141,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/climatic-condition/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/climatic-condition/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/climatic-condition/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/climatic-condition/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/climatic-condition/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/climatic-condition/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:climatic-condition:used-procedure>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description """IRI of procedure _MUST_ have the value `https://linked.data.gov.au/def/test/dawe-cv/1ff9e97c-3bdd-44c9-bdd3-401fa31c0b32`.
@@ -173,17 +173,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/climatic-condition/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/climatic-condition/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/climatic-condition/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/climatic-condition/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/climatic-condition/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/climatic-condition/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:climatic-condition:value-type>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:class tern:IRI ;
@@ -203,17 +203,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/climatic-condition/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/climatic-condition/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/climatic-condition/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/climatic-condition/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/climatic-condition/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/climatic-condition/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:climatic-condition:vocabulary>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description """IRI of `tern:vocabulary` in `sosa:hasResult` _MUST_ have the value `https://linked.data.gov.au/def/test/dawe-cv/2ebfee89-92db-44b3-bb89-06dd92798ae6`.
@@ -236,10 +236,10 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/climatic-condition/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/climatic-condition/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/climatic-condition/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/climatic-condition/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/climatic-condition/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/climatic-condition/shapes.ttl"^^xsd:anyURI ;
 .
 

--- a/shapes/plot-description/climatic-condition/valid.ttl
+++ b/shapes/plot-description/climatic-condition/valid.ttl
@@ -1,4 +1,3 @@
-
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX sosa: <http://www.w3.org/ns/sosa/>
 PREFIX tern: <https://w3id.org/tern/ontologies/tern/>

--- a/shapes/plot-description/cover-class/invalid.ttl
+++ b/shapes/plot-description/cover-class/invalid.ttl
@@ -1,4 +1,3 @@
-
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX sosa: <http://www.w3.org/ns/sosa/>

--- a/shapes/plot-description/cover-class/shapes.ttl
+++ b/shapes/plot-description/cover-class/shapes.ttl
@@ -1,17 +1,17 @@
-
 PREFIX dcterms: <http://purl.org/dc/terms/>
-PREFIX ns1: <urn:property:>
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX reg: <http://purl.org/linked-data/registry#>
 PREFIX sh: <http://www.w3.org/ns/shacl#>
 PREFIX sosa: <http://www.w3.org/ns/sosa/>
 PREFIX tern: <https://w3id.org/tern/ontologies/tern/>
+PREFIX urnc: <urn:class:>
+PREFIX urnp: <urn:property:>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <urn:shapes:plot-description:cover-class:feature-type>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "TERN's ecologists have determined the feature type is _vegetation_, defined by the link:https://www.publish.csiro.au/book/5230/[Australian Soil and Land Survey Field Handbook]." ;
@@ -32,18 +32,18 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-class/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-class/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-class/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-class/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-class/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-class/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:cover-class:result-value>
     a
         sh:PropertyShape ,
-        <urn:class:Controlled> ,
-        <urn:class:Requirement> ;
+        urnc:Controlled ,
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "The value in `sosa:hasResult` _MUST_ be a value in `sh:in`, which is the Cover class codes controlled vocabulary." ;
@@ -71,11 +71,11 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-class/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-class/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-class/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-class/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:query """
+    urnp:query """
             PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
             select ?values {
                     ?s skos:member ?values .
@@ -83,14 +83,14 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             }
 
     """ ;
-    ns1:sparqlEndpoint "https://graphdb.tern.org.au/repositories/dawe_vocabs_core" ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-class/shapes.ttl"^^xsd:anyURI ;
+    urnp:sparqlEndpoint "https://graphdb.tern.org.au/repositories/dawe_vocabs_core" ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-class/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:cover-class:simple-result>
     a
         sh:NodeShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "Value of `sosa:hasSimpleResult` _MUST_ be the same as the value in `sosa:hasResult`." ;
@@ -113,17 +113,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     """
         ] ;
     sh:targetClass tern:Observation ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-class/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-class/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-class/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-class/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-class/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-class/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:cover-class:site-visit>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "Observations following the Plot Description protocol are made in the context of a site visit." ;
@@ -145,17 +145,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-class/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-class/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-class/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-class/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-class/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-class/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:cover-class:used-procedure>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description """IRI of procedure _MUST_ have the value `https://linked.data.gov.au/def/test/dawe-cv/1ff9e97c-3bdd-44c9-bdd3-401fa31c0b32`.
@@ -177,17 +177,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-class/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-class/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-class/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-class/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-class/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-class/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:cover-class:value-type>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:class tern:IRI ;
@@ -207,17 +207,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-class/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-class/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-class/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-class/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-class/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-class/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:cover-class:vocabulary>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description """IRI of `tern:vocabulary` in `sosa:hasResult` _MUST_ have the value `https://linked.data.gov.au/def/test/dawe-cv/6aaa330c-3d60-419b-a29b-a2dbc6d67928`.
@@ -240,10 +240,10 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-class/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-class/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-class/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-class/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-class/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-class/shapes.ttl"^^xsd:anyURI ;
 .
 

--- a/shapes/plot-description/cover-class/valid.ttl
+++ b/shapes/plot-description/cover-class/valid.ttl
@@ -1,4 +1,3 @@
-
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX sosa: <http://www.w3.org/ns/sosa/>
 PREFIX tern: <https://w3id.org/tern/ontologies/tern/>

--- a/shapes/plot-description/cover-percentage/invalid.ttl
+++ b/shapes/plot-description/cover-percentage/invalid.ttl
@@ -1,4 +1,3 @@
-
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX sosa: <http://www.w3.org/ns/sosa/>

--- a/shapes/plot-description/cover-percentage/shapes.ttl
+++ b/shapes/plot-description/cover-percentage/shapes.ttl
@@ -1,17 +1,17 @@
-
 PREFIX dcterms: <http://purl.org/dc/terms/>
-PREFIX ns1: <urn:property:>
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX reg: <http://purl.org/linked-data/registry#>
 PREFIX sh: <http://www.w3.org/ns/shacl#>
 PREFIX sosa: <http://www.w3.org/ns/sosa/>
 PREFIX tern: <https://w3id.org/tern/ontologies/tern/>
+PREFIX urnc: <urn:class:>
+PREFIX urnp: <urn:property:>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <urn:shapes:plot-description:cover-percentage:feature-type>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "TERN's ecologists have determined the feature type is _vegetation_, defined by the link:https://www.publish.csiro.au/book/5230/[Australian Soil and Land Survey Field Handbook]." ;
@@ -32,17 +32,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-percentage/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-percentage/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-percentage/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-percentage/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-percentage/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-percentage/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:cover-percentage:simple-result>
     a
         sh:NodeShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "Value of `sosa:hasSimpleResult` _MUST_ be the same as the value in `sosa:hasResult`." ;
@@ -65,17 +65,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     """
         ] ;
     sh:targetClass tern:Observation ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-percentage/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-percentage/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-percentage/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-percentage/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-percentage/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-percentage/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:cover-percentage:site-visit>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "Observations following the Plot Description protocol are made in the context of a site visit." ;
@@ -97,17 +97,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-percentage/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-percentage/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-percentage/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-percentage/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-percentage/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-percentage/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:cover-percentage:unit-of-measure>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "Result value's unit of measure _MUST_ have the value `unit:PERCENT`." ;
@@ -128,17 +128,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-percentage/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-percentage/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-percentage/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-percentage/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-percentage/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-percentage/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:cover-percentage:used-procedure>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description """IRI of procedure _MUST_ have the value `https://linked.data.gov.au/def/test/dawe-cv/1ff9e97c-3bdd-44c9-bdd3-401fa31c0b32`.
@@ -160,17 +160,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-percentage/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-percentage/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-percentage/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-percentage/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-percentage/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-percentage/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:cover-percentage:value-range>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "Value _MUST_ be between 0 and 100 inclusive." ;
@@ -192,17 +192,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-percentage/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-percentage/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-percentage/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-percentage/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-percentage/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-percentage/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:cover-percentage:value-type>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:class tern:Float ;
@@ -222,10 +222,10 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-percentage/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-percentage/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-percentage/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-percentage/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-percentage/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-percentage/shapes.ttl"^^xsd:anyURI ;
 .
 

--- a/shapes/plot-description/cover-percentage/valid.ttl
+++ b/shapes/plot-description/cover-percentage/valid.ttl
@@ -1,4 +1,3 @@
-
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX sosa: <http://www.w3.org/ns/sosa/>

--- a/shapes/plot-description/disturbance/invalid.ttl
+++ b/shapes/plot-description/disturbance/invalid.ttl
@@ -1,4 +1,3 @@
-
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX sosa: <http://www.w3.org/ns/sosa/>

--- a/shapes/plot-description/disturbance/shapes.ttl
+++ b/shapes/plot-description/disturbance/shapes.ttl
@@ -1,17 +1,17 @@
-
 PREFIX dcterms: <http://purl.org/dc/terms/>
-PREFIX ns1: <urn:property:>
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX reg: <http://purl.org/linked-data/registry#>
 PREFIX sh: <http://www.w3.org/ns/shacl#>
 PREFIX sosa: <http://www.w3.org/ns/sosa/>
 PREFIX tern: <https://w3id.org/tern/ontologies/tern/>
+PREFIX urnc: <urn:class:>
+PREFIX urnp: <urn:property:>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <urn:shapes:plot-description:disturbance:feature-type>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "TERN's ecologists have determined the feature type is _vegetation disturbance_, defined by the link:https://www.publish.csiro.au/book/5230/[Australian Soil and Land Survey Field Handbook]." ;
@@ -32,18 +32,18 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/disturbance/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/disturbance/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/disturbance/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/disturbance/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/disturbance/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/disturbance/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:disturbance:result-value>
     a
         sh:PropertyShape ,
-        <urn:class:Controlled> ,
-        <urn:class:Requirement> ;
+        urnc:Controlled ,
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "The value in `sosa:hasResult` _MUST_ be a value in `sh:in`, which is the Disturbance type codes controlled vocabulary." ;
@@ -77,11 +77,11 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/disturbance/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/disturbance/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/disturbance/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/disturbance/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:query """
+    urnp:query """
             PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
             select ?values {
                     ?s skos:member ?values .
@@ -89,14 +89,14 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             }
 
     """ ;
-    ns1:sparqlEndpoint "https://graphdb.tern.org.au/repositories/dawe_vocabs_core" ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/disturbance/shapes.ttl"^^xsd:anyURI ;
+    urnp:sparqlEndpoint "https://graphdb.tern.org.au/repositories/dawe_vocabs_core" ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/disturbance/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:disturbance:simple-result>
     a
         sh:NodeShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "Value of `sosa:hasSimpleResult` _MUST_ be the same as the value in `sosa:hasResult`." ;
@@ -119,17 +119,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     """
         ] ;
     sh:targetClass tern:Observation ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/disturbance/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/disturbance/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/disturbance/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/disturbance/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/disturbance/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/disturbance/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:disturbance:site-visit>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "Observations following the Plot Description protocol are made in the context of a site visit." ;
@@ -151,17 +151,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/disturbance/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/disturbance/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/disturbance/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/disturbance/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/disturbance/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/disturbance/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:disturbance:used-procedure>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description """IRI of procedure _MUST_ have the value `https://linked.data.gov.au/def/test/dawe-cv/1ff9e97c-3bdd-44c9-bdd3-401fa31c0b32`.
@@ -183,17 +183,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/disturbance/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/disturbance/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/disturbance/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/disturbance/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/disturbance/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/disturbance/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:disturbance:value-type>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:class tern:IRI ;
@@ -213,17 +213,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/disturbance/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/disturbance/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/disturbance/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/disturbance/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/disturbance/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/disturbance/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:disturbance:vocabulary>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description """IRI of `tern:vocabulary` in `sosa:hasResult` _MUST_ have the value `https://linked.data.gov.au/def/test/dawe-cv/f5a470e8-d29f-4ff6-b50d-529b0444dbe4`.
@@ -246,10 +246,10 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/disturbance/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/disturbance/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/disturbance/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/disturbance/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/disturbance/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/disturbance/shapes.ttl"^^xsd:anyURI ;
 .
 

--- a/shapes/plot-description/disturbance/valid.ttl
+++ b/shapes/plot-description/disturbance/valid.ttl
@@ -1,4 +1,3 @@
-
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX sosa: <http://www.w3.org/ns/sosa/>
 PREFIX tern: <https://w3id.org/tern/ontologies/tern/>

--- a/shapes/plot-description/fire-history/invalid.ttl
+++ b/shapes/plot-description/fire-history/invalid.ttl
@@ -1,4 +1,3 @@
-
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX sosa: <http://www.w3.org/ns/sosa/>

--- a/shapes/plot-description/fire-history/shapes.ttl
+++ b/shapes/plot-description/fire-history/shapes.ttl
@@ -1,17 +1,17 @@
-
 PREFIX dcterms: <http://purl.org/dc/terms/>
-PREFIX ns1: <urn:property:>
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX reg: <http://purl.org/linked-data/registry#>
 PREFIX sh: <http://www.w3.org/ns/shacl#>
 PREFIX sosa: <http://www.w3.org/ns/sosa/>
 PREFIX tern: <https://w3id.org/tern/ontologies/tern/>
+PREFIX urnc: <urn:class:>
+PREFIX urnp: <urn:property:>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <urn:shapes:plot-description:fire-history:feature-type>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "TERN's ecologists have determined the feature type is _vegetation disturbance_, defined by the link:https://www.publish.csiro.au/book/5230/[Australian Soil and Land Survey Field Handbook]." ;
@@ -32,18 +32,18 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/fire-history/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/fire-history/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/fire-history/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/fire-history/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/fire-history/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/fire-history/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:fire-history:result-value>
     a
         sh:PropertyShape ,
-        <urn:class:Controlled> ,
-        <urn:class:Requirement> ;
+        urnc:Controlled ,
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "The value in `sosa:hasResult` _MUST_ be a value in `sh:in`, which is the Fire history codes controlled vocabulary." ;
@@ -68,11 +68,11 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/fire-history/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/fire-history/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/fire-history/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/fire-history/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:query """
+    urnp:query """
             PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
             select ?values {
                     ?s skos:member ?values .
@@ -80,14 +80,14 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             }
 
     """ ;
-    ns1:sparqlEndpoint "https://graphdb.tern.org.au/repositories/dawe_vocabs_core" ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/fire-history/shapes.ttl"^^xsd:anyURI ;
+    urnp:sparqlEndpoint "https://graphdb.tern.org.au/repositories/dawe_vocabs_core" ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/fire-history/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:fire-history:simple-result>
     a
         sh:NodeShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "Value of `sosa:hasSimpleResult` _MUST_ be the same as the value in `sosa:hasResult`." ;
@@ -110,17 +110,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     """
         ] ;
     sh:targetClass tern:Observation ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/fire-history/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/fire-history/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/fire-history/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/fire-history/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/fire-history/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/fire-history/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:fire-history:site-visit>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "Observations following the Plot Description protocol are made in the context of a site visit." ;
@@ -142,17 +142,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/fire-history/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/fire-history/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/fire-history/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/fire-history/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/fire-history/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/fire-history/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:fire-history:used-procedure>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description """IRI of procedure _MUST_ have the value `https://linked.data.gov.au/def/test/dawe-cv/1ff9e97c-3bdd-44c9-bdd3-401fa31c0b32`.
@@ -174,17 +174,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/fire-history/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/fire-history/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/fire-history/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/fire-history/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/fire-history/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/fire-history/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:fire-history:value-type>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:class tern:IRI ;
@@ -204,17 +204,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/fire-history/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/fire-history/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/fire-history/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/fire-history/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/fire-history/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/fire-history/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:fire-history:vocabulary>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description """IRI of `tern:vocabulary` in `sosa:hasResult` _MUST_ have the value `https://linked.data.gov.au/def/test/dawe-cv/6e9d2f51-ce64-4c67-8391-d14a8bf96b6b`.
@@ -237,10 +237,10 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/fire-history/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/fire-history/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/fire-history/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/fire-history/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/fire-history/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/fire-history/shapes.ttl"^^xsd:anyURI ;
 .
 

--- a/shapes/plot-description/fire-history/valid.ttl
+++ b/shapes/plot-description/fire-history/valid.ttl
@@ -1,4 +1,3 @@
-
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX sosa: <http://www.w3.org/ns/sosa/>
 PREFIX tern: <https://w3id.org/tern/ontologies/tern/>

--- a/shapes/plot-description/growth-form/invalid.ttl
+++ b/shapes/plot-description/growth-form/invalid.ttl
@@ -1,4 +1,3 @@
-
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX sosa: <http://www.w3.org/ns/sosa/>

--- a/shapes/plot-description/growth-form/shapes.ttl
+++ b/shapes/plot-description/growth-form/shapes.ttl
@@ -1,17 +1,17 @@
-
 PREFIX dcterms: <http://purl.org/dc/terms/>
-PREFIX ns1: <urn:property:>
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX reg: <http://purl.org/linked-data/registry#>
 PREFIX sh: <http://www.w3.org/ns/shacl#>
 PREFIX sosa: <http://www.w3.org/ns/sosa/>
 PREFIX tern: <https://w3id.org/tern/ontologies/tern/>
+PREFIX urnc: <urn:class:>
+PREFIX urnp: <urn:property:>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <urn:shapes:plot-description:growth-form:feature-type>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "TERN's ecologists have determined the feature type is _vegetation_, defined by the link:https://www.publish.csiro.au/book/5230/[Australian Soil and Land Survey Field Handbook]." ;
@@ -32,18 +32,18 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-form/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-form/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-form/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-form/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-form/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-form/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:growth-form:result-value>
     a
         sh:PropertyShape ,
-        <urn:class:Controlled> ,
-        <urn:class:Requirement> ;
+        urnc:Controlled ,
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "The value in `sosa:hasResult` _MUST_ be a value in `sh:in`, which is the Vegetation growth form codes controlled vocabulary." ;
@@ -86,11 +86,11 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-form/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-form/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-form/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-form/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:query """
+    urnp:query """
             PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
             select ?values {
                     ?s skos:member ?values .
@@ -98,14 +98,14 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             }
 
     """ ;
-    ns1:sparqlEndpoint "https://graphdb.tern.org.au/repositories/dawe_vocabs_core" ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-form/shapes.ttl"^^xsd:anyURI ;
+    urnp:sparqlEndpoint "https://graphdb.tern.org.au/repositories/dawe_vocabs_core" ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-form/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:growth-form:simple-result>
     a
         sh:NodeShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "Value of `sosa:hasSimpleResult` _MUST_ be the same as the value in `sosa:hasResult`." ;
@@ -128,17 +128,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     """
         ] ;
     sh:targetClass tern:Observation ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-form/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-form/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-form/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-form/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-form/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-form/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:growth-form:site-visit>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "Observations following the Plot Description protocol are made in the context of a site visit." ;
@@ -160,17 +160,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-form/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-form/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-form/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-form/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-form/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-form/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:growth-form:used-procedure>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description """IRI of procedure _MUST_ have the value `https://linked.data.gov.au/def/test/dawe-cv/1ff9e97c-3bdd-44c9-bdd3-401fa31c0b32`.
@@ -192,17 +192,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-form/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-form/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-form/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-form/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-form/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-form/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:growth-form:value-type>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:class tern:IRI ;
@@ -222,17 +222,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-form/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-form/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-form/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-form/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-form/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-form/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:growth-form:vocabulary>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description """IRI of `tern:vocabulary` in `sosa:hasResult` _MUST_ have the value `https://linked.data.gov.au/def/test/dawe-cv/d0fc07a7-3ec9-45ed-8850-885a32828d3c`.
@@ -255,10 +255,10 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-form/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-form/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-form/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-form/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-form/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-form/shapes.ttl"^^xsd:anyURI ;
 .
 

--- a/shapes/plot-description/growth-form/valid.ttl
+++ b/shapes/plot-description/growth-form/valid.ttl
@@ -1,4 +1,3 @@
-
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX sosa: <http://www.w3.org/ns/sosa/>
 PREFIX tern: <https://w3id.org/tern/ontologies/tern/>

--- a/shapes/plot-description/growth-stage/invalid.ttl
+++ b/shapes/plot-description/growth-stage/invalid.ttl
@@ -1,4 +1,3 @@
-
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX sosa: <http://www.w3.org/ns/sosa/>

--- a/shapes/plot-description/growth-stage/shapes.ttl
+++ b/shapes/plot-description/growth-stage/shapes.ttl
@@ -1,17 +1,17 @@
-
 PREFIX dcterms: <http://purl.org/dc/terms/>
-PREFIX ns1: <urn:property:>
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX reg: <http://purl.org/linked-data/registry#>
 PREFIX sh: <http://www.w3.org/ns/shacl#>
 PREFIX sosa: <http://www.w3.org/ns/sosa/>
 PREFIX tern: <https://w3id.org/tern/ontologies/tern/>
+PREFIX urnc: <urn:class:>
+PREFIX urnp: <urn:property:>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <urn:shapes:plot-description:growth-stage:feature-type>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "TERN's ecologists have determined the feature type is _vegetation_, defined by the link:https://www.publish.csiro.au/book/5230/[Australian Soil and Land Survey Field Handbook]." ;
@@ -32,18 +32,18 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-stage/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-stage/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-stage/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-stage/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-stage/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-stage/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:growth-stage:result-value>
     a
         sh:PropertyShape ,
-        <urn:class:Controlled> ,
-        <urn:class:Requirement> ;
+        urnc:Controlled ,
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "The value in `sosa:hasResult` _MUST_ be a value in `sh:in`, which is the Vegetation growth stage codes controlled vocabulary." ;
@@ -70,11 +70,11 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-stage/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-stage/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-stage/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-stage/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:query """
+    urnp:query """
             PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
             select ?values {
                     ?s skos:member ?values .
@@ -82,14 +82,14 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             }
 
     """ ;
-    ns1:sparqlEndpoint "https://graphdb.tern.org.au/repositories/dawe_vocabs_core" ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-stage/shapes.ttl"^^xsd:anyURI ;
+    urnp:sparqlEndpoint "https://graphdb.tern.org.au/repositories/dawe_vocabs_core" ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-stage/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:growth-stage:simple-result>
     a
         sh:NodeShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "Value of `sosa:hasSimpleResult` _MUST_ be the same as the value in `sosa:hasResult`." ;
@@ -112,17 +112,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     """
         ] ;
     sh:targetClass tern:Observation ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-stage/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-stage/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-stage/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-stage/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-stage/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-stage/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:growth-stage:site-visit>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "Observations following the Plot Description protocol are made in the context of a site visit." ;
@@ -144,17 +144,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-stage/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-stage/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-stage/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-stage/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-stage/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-stage/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:growth-stage:used-procedure>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description """IRI of procedure _MUST_ have the value `https://linked.data.gov.au/def/test/dawe-cv/1ff9e97c-3bdd-44c9-bdd3-401fa31c0b32`.
@@ -176,17 +176,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-stage/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-stage/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-stage/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-stage/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-stage/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-stage/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:growth-stage:value-type>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:class tern:IRI ;
@@ -206,17 +206,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-stage/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-stage/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-stage/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-stage/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-stage/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-stage/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:growth-stage:vocabulary>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description """IRI of `tern:vocabulary` in `sosa:hasResult` _MUST_ have the value `https://linked.data.gov.au/def/test/dawe-cv/89c02383-fb5e-4acd-b248-902a2d579170`.
@@ -239,10 +239,10 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-stage/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-stage/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-stage/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-stage/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-stage/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-stage/shapes.ttl"^^xsd:anyURI ;
 .
 

--- a/shapes/plot-description/growth-stage/valid.ttl
+++ b/shapes/plot-description/growth-stage/valid.ttl
@@ -1,4 +1,3 @@
-
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX sosa: <http://www.w3.org/ns/sosa/>
 PREFIX tern: <https://w3id.org/tern/ontologies/tern/>

--- a/shapes/plot-description/height-class/invalid.ttl
+++ b/shapes/plot-description/height-class/invalid.ttl
@@ -1,4 +1,3 @@
-
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX sosa: <http://www.w3.org/ns/sosa/>

--- a/shapes/plot-description/height-class/shapes.ttl
+++ b/shapes/plot-description/height-class/shapes.ttl
@@ -1,17 +1,17 @@
-
 PREFIX dcterms: <http://purl.org/dc/terms/>
-PREFIX ns1: <urn:property:>
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX reg: <http://purl.org/linked-data/registry#>
 PREFIX sh: <http://www.w3.org/ns/shacl#>
 PREFIX sosa: <http://www.w3.org/ns/sosa/>
 PREFIX tern: <https://w3id.org/tern/ontologies/tern/>
+PREFIX urnc: <urn:class:>
+PREFIX urnp: <urn:property:>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <urn:shapes:plot-description:height-class:feature-type>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "TERN's ecologists have determined the feature type is _vegetation_, defined by the link:https://www.publish.csiro.au/book/5230/[Australian Soil and Land Survey Field Handbook]." ;
@@ -32,18 +32,18 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/height-class/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/height-class/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/height-class/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/height-class/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/height-class/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/height-class/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:height-class:result-value>
     a
         sh:PropertyShape ,
-        <urn:class:Controlled> ,
-        <urn:class:Requirement> ;
+        urnc:Controlled ,
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "The value in `sosa:hasResult` _MUST_ be a value in `sh:in`, which is the Vegetation height class codes controlled vocabulary." ;
@@ -73,11 +73,11 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/height-class/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/height-class/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/height-class/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/height-class/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:query """
+    urnp:query """
             PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
             select ?values {
                     ?s skos:member ?values .
@@ -85,14 +85,14 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             }
 
     """ ;
-    ns1:sparqlEndpoint "https://graphdb.tern.org.au/repositories/dawe_vocabs_core" ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/height-class/shapes.ttl"^^xsd:anyURI ;
+    urnp:sparqlEndpoint "https://graphdb.tern.org.au/repositories/dawe_vocabs_core" ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/height-class/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:height-class:simple-result>
     a
         sh:NodeShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "Value of `sosa:hasSimpleResult` _MUST_ be the same as the value in `sosa:hasResult`." ;
@@ -115,17 +115,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     """
         ] ;
     sh:targetClass tern:Observation ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/height-class/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/height-class/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/height-class/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/height-class/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/height-class/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/height-class/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:height-class:site-visit>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "Observations following the Plot Description protocol are made in the context of a site visit." ;
@@ -147,17 +147,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/height-class/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/height-class/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/height-class/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/height-class/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/height-class/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/height-class/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:height-class:used-procedure>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description """IRI of procedure _MUST_ have the value `https://linked.data.gov.au/def/test/dawe-cv/1ff9e97c-3bdd-44c9-bdd3-401fa31c0b32`.
@@ -179,17 +179,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/height-class/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/height-class/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/height-class/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/height-class/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/height-class/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/height-class/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:height-class:value-type>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:class tern:IRI ;
@@ -209,17 +209,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/height-class/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/height-class/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/height-class/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/height-class/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/height-class/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/height-class/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:height-class:vocabulary>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description """IRI of `tern:vocabulary` in `sosa:hasResult` _MUST_ have the value `https://linked.data.gov.au/def/test/dawe-cv/b1b05cd1-3b85-4639-a6af-799a34d88d43`.
@@ -242,10 +242,10 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/height-class/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/height-class/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/height-class/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/height-class/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/height-class/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/height-class/shapes.ttl"^^xsd:anyURI ;
 .
 

--- a/shapes/plot-description/height-class/valid.ttl
+++ b/shapes/plot-description/height-class/valid.ttl
@@ -1,4 +1,3 @@
-
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX sosa: <http://www.w3.org/ns/sosa/>
 PREFIX tern: <https://w3id.org/tern/ontologies/tern/>

--- a/shapes/plot-description/homogeneity-measure/invalid.ttl
+++ b/shapes/plot-description/homogeneity-measure/invalid.ttl
@@ -1,4 +1,3 @@
-
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX sosa: <http://www.w3.org/ns/sosa/>

--- a/shapes/plot-description/homogeneity-measure/shapes.ttl
+++ b/shapes/plot-description/homogeneity-measure/shapes.ttl
@@ -1,17 +1,17 @@
-
 PREFIX dcterms: <http://purl.org/dc/terms/>
-PREFIX ns1: <urn:property:>
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX reg: <http://purl.org/linked-data/registry#>
 PREFIX sh: <http://www.w3.org/ns/shacl#>
 PREFIX sosa: <http://www.w3.org/ns/sosa/>
 PREFIX tern: <https://w3id.org/tern/ontologies/tern/>
+PREFIX urnc: <urn:class:>
+PREFIX urnp: <urn:property:>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <urn:shapes:plot-description:homogeneity-measure:feature-type>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "TERN's ecologists have determined the feature type is _vegetation_, defined by the link:https://www.publish.csiro.au/book/5230/[Australian Soil and Land Survey Field Handbook]." ;
@@ -32,17 +32,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/homogeneity-measure/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/homogeneity-measure/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/homogeneity-measure/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/homogeneity-measure/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/homogeneity-measure/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/homogeneity-measure/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:homogeneity-measure:simple-result>
     a
         sh:NodeShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "Value of `sosa:hasSimpleResult` _MUST_ be the same as the value in `sosa:hasResult`." ;
@@ -65,17 +65,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     """
         ] ;
     sh:targetClass tern:Observation ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/homogeneity-measure/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/homogeneity-measure/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/homogeneity-measure/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/homogeneity-measure/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/homogeneity-measure/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/homogeneity-measure/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:homogeneity-measure:site-visit>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "Observations following the Plot Description protocol are made in the context of a site visit." ;
@@ -97,17 +97,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/homogeneity-measure/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/homogeneity-measure/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/homogeneity-measure/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/homogeneity-measure/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/homogeneity-measure/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/homogeneity-measure/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:homogeneity-measure:unit-of-measure>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "Result value's unit of measure _MUST_ have the value `unit:M`." ;
@@ -128,17 +128,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/homogeneity-measure/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/homogeneity-measure/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/homogeneity-measure/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/homogeneity-measure/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/homogeneity-measure/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/homogeneity-measure/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:homogeneity-measure:used-procedure>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description """IRI of procedure _MUST_ have the value `https://linked.data.gov.au/def/test/dawe-cv/1ff9e97c-3bdd-44c9-bdd3-401fa31c0b32`.
@@ -160,17 +160,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/homogeneity-measure/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/homogeneity-measure/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/homogeneity-measure/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/homogeneity-measure/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/homogeneity-measure/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/homogeneity-measure/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:homogeneity-measure:value-range>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "Value _MUST_ not be negative." ;
@@ -191,17 +191,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/homogeneity-measure/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/homogeneity-measure/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/homogeneity-measure/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/homogeneity-measure/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/homogeneity-measure/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/homogeneity-measure/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:homogeneity-measure:value-type>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:class tern:Float ;
@@ -221,10 +221,10 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/homogeneity-measure/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/homogeneity-measure/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/homogeneity-measure/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/homogeneity-measure/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/homogeneity-measure/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/homogeneity-measure/shapes.ttl"^^xsd:anyURI ;
 .
 

--- a/shapes/plot-description/homogeneity-measure/valid.ttl
+++ b/shapes/plot-description/homogeneity-measure/valid.ttl
@@ -1,4 +1,3 @@
-
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX sosa: <http://www.w3.org/ns/sosa/>

--- a/shapes/plot-description/landform-element/invalid.ttl
+++ b/shapes/plot-description/landform-element/invalid.ttl
@@ -1,4 +1,3 @@
-
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX sosa: <http://www.w3.org/ns/sosa/>

--- a/shapes/plot-description/landform-element/shapes.ttl
+++ b/shapes/plot-description/landform-element/shapes.ttl
@@ -1,17 +1,17 @@
-
 PREFIX dcterms: <http://purl.org/dc/terms/>
-PREFIX ns1: <urn:property:>
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX reg: <http://purl.org/linked-data/registry#>
 PREFIX sh: <http://www.w3.org/ns/shacl#>
 PREFIX sosa: <http://www.w3.org/ns/sosa/>
 PREFIX tern: <https://w3id.org/tern/ontologies/tern/>
+PREFIX urnc: <urn:class:>
+PREFIX urnp: <urn:property:>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <urn:shapes:plot-description:landform-element:feature-type>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "TERN's ecologists have determined the feature type is _landform_, defined by the link:https://www.publish.csiro.au/book/5230/[Australian Soil and Land Survey Field Handbook]." ;
@@ -32,18 +32,18 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-element/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-element/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-element/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-element/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-element/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-element/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:landform-element:result-value>
     a
         sh:PropertyShape ,
-        <urn:class:Controlled> ,
-        <urn:class:Requirement> ;
+        urnc:Controlled ,
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "The value in `sosa:hasResult` _MUST_ be a value in `sh:in`, which is the landform element codes controlled vocabulary." ;
@@ -162,11 +162,11 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-element/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-element/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-element/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-element/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:query """
+    urnp:query """
             PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
             select ?values {
                     ?s skos:member ?values .
@@ -174,14 +174,14 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             }
 
     """ ;
-    ns1:sparqlEndpoint "https://graphdb.tern.org.au/repositories/dawe_vocabs_core" ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-element/shapes.ttl"^^xsd:anyURI ;
+    urnp:sparqlEndpoint "https://graphdb.tern.org.au/repositories/dawe_vocabs_core" ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-element/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:landform-element:simple-result>
     a
         sh:NodeShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "Value of `sosa:hasSimpleResult` _MUST_ be the same as the value in `sosa:hasResult`." ;
@@ -204,17 +204,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     """
         ] ;
     sh:targetClass tern:Observation ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-element/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-element/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-element/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-element/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-element/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-element/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:landform-element:site-visit>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "Observations following the Plot Description protocol are made in the context of a site visit." ;
@@ -236,17 +236,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-element/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-element/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-element/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-element/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-element/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-element/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:landform-element:used-procedure>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description """IRI of procedure _MUST_ have the value `https://linked.data.gov.au/def/test/dawe-cv/1ff9e97c-3bdd-44c9-bdd3-401fa31c0b32`.
@@ -268,17 +268,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-element/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-element/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-element/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-element/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-element/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-element/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:landform-element:value-type>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:class tern:IRI ;
@@ -298,17 +298,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-element/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-element/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-element/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-element/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-element/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-element/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:landform-element:vocabulary>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description """IRI of `tern:vocabulary` in `sosa:hasResult` _MUST_ have the value `https://linked.data.gov.au/def/test/dawe-cv/c1a58967-cb12-4c2c-a7ca-9cee2589919c`.
@@ -331,10 +331,10 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-element/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-element/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-element/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-element/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-element/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-element/shapes.ttl"^^xsd:anyURI ;
 .
 

--- a/shapes/plot-description/landform-element/valid.ttl
+++ b/shapes/plot-description/landform-element/valid.ttl
@@ -1,4 +1,3 @@
-
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX sosa: <http://www.w3.org/ns/sosa/>
 PREFIX tern: <https://w3id.org/tern/ontologies/tern/>

--- a/shapes/plot-description/landform-pattern/invalid.ttl
+++ b/shapes/plot-description/landform-pattern/invalid.ttl
@@ -1,4 +1,3 @@
-
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX sosa: <http://www.w3.org/ns/sosa/>

--- a/shapes/plot-description/landform-pattern/shapes.ttl
+++ b/shapes/plot-description/landform-pattern/shapes.ttl
@@ -1,17 +1,17 @@
-
 PREFIX dcterms: <http://purl.org/dc/terms/>
-PREFIX ns1: <urn:property:>
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX reg: <http://purl.org/linked-data/registry#>
 PREFIX sh: <http://www.w3.org/ns/shacl#>
 PREFIX sosa: <http://www.w3.org/ns/sosa/>
 PREFIX tern: <https://w3id.org/tern/ontologies/tern/>
+PREFIX urnc: <urn:class:>
+PREFIX urnp: <urn:property:>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <urn:shapes:plot-description:landform-pattern:feature-type>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "TERN's ecologists have determined the feature type is _landform_, defined by the link:https://www.publish.csiro.au/book/5230/[Australian Soil and Land Survey Field Handbook]." ;
@@ -32,18 +32,18 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-pattern/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-pattern/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-pattern/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-pattern/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-pattern/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-pattern/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:landform-pattern:result-value>
     a
         sh:PropertyShape ,
-        <urn:class:Controlled> ,
-        <urn:class:Requirement> ;
+        urnc:Controlled ,
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "The value in `sosa:hasResult` _MUST_ be a value in `sh:in`, which is the landform pattern codes controlled vocabulary." ;
@@ -106,11 +106,11 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-pattern/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-pattern/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-pattern/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-pattern/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:query """
+    urnp:query """
             PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
             select ?values {
                     ?s skos:member ?values .
@@ -118,14 +118,14 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             }
 
     """ ;
-    ns1:sparqlEndpoint "https://graphdb.tern.org.au/repositories/dawe_vocabs_core" ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-pattern/shapes.ttl"^^xsd:anyURI ;
+    urnp:sparqlEndpoint "https://graphdb.tern.org.au/repositories/dawe_vocabs_core" ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-pattern/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:landform-pattern:simple-result>
     a
         sh:NodeShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "Value of `sosa:hasSimpleResult` _MUST_ be the same as the value in `sosa:hasResult`." ;
@@ -148,17 +148,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     """
         ] ;
     sh:targetClass tern:Observation ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-pattern/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-pattern/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-pattern/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-pattern/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-pattern/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-pattern/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:landform-pattern:site-visit>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "Observations following the Plot Description protocol are made in the context of a site visit." ;
@@ -180,17 +180,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-pattern/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-pattern/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-pattern/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-pattern/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-pattern/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-pattern/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:landform-pattern:used-procedure>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description """IRI of procedure _MUST_ have the value `https://linked.data.gov.au/def/test/dawe-cv/1ff9e97c-3bdd-44c9-bdd3-401fa31c0b32`.
@@ -212,17 +212,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-pattern/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-pattern/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-pattern/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-pattern/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-pattern/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-pattern/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:landform-pattern:value-type>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:class tern:IRI ;
@@ -242,17 +242,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-pattern/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-pattern/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-pattern/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-pattern/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-pattern/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-pattern/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:landform-pattern:vocabulary>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description """IRI of `tern:vocabulary` in `sosa:hasResult` _MUST_ have the value `https://linked.data.gov.au/def/test/dawe-cv/19d91a7a-2733-4b84-9d2b-4bda4808c003`.
@@ -275,10 +275,10 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-pattern/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-pattern/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-pattern/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-pattern/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-pattern/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-pattern/shapes.ttl"^^xsd:anyURI ;
 .
 

--- a/shapes/plot-description/landform-pattern/valid.ttl
+++ b/shapes/plot-description/landform-pattern/valid.ttl
@@ -1,4 +1,3 @@
-
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX sosa: <http://www.w3.org/ns/sosa/>
 PREFIX tern: <https://w3id.org/tern/ontologies/tern/>

--- a/shapes/plot-description/most-dominant-species/invalid.ttl
+++ b/shapes/plot-description/most-dominant-species/invalid.ttl
@@ -1,4 +1,3 @@
-
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX sosa: <http://www.w3.org/ns/sosa/>

--- a/shapes/plot-description/most-dominant-species/shapes.ttl
+++ b/shapes/plot-description/most-dominant-species/shapes.ttl
@@ -1,17 +1,17 @@
-
 PREFIX dcterms: <http://purl.org/dc/terms/>
-PREFIX ns1: <urn:property:>
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX reg: <http://purl.org/linked-data/registry#>
 PREFIX sh: <http://www.w3.org/ns/shacl#>
 PREFIX sosa: <http://www.w3.org/ns/sosa/>
 PREFIX tern: <https://w3id.org/tern/ontologies/tern/>
+PREFIX urnc: <urn:class:>
+PREFIX urnp: <urn:property:>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <urn:shapes:plot-description:most-dominant-species:feature-type>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "TERN's ecologists have determined the feature type is _vegetation stratum_, defined by the link:https://www.publish.csiro.au/book/5230/[Australian Soil and Land Survey Field Handbook]." ;
@@ -32,17 +32,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/most-dominant-species/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/most-dominant-species/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/most-dominant-species/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/most-dominant-species/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/most-dominant-species/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/most-dominant-species/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:most-dominant-species:result-value>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "The value in `sosa:hasResult` _MUST_ match the pattern `biodiversity.org.au/boa/name/apni`, which is part of the searching result." ;
@@ -63,17 +63,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/most-dominant-species/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/most-dominant-species/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/most-dominant-species/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/most-dominant-species/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/most-dominant-species/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/most-dominant-species/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:most-dominant-species:simple-result>
     a
         sh:NodeShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "Value of `sosa:hasSimpleResult` _MUST_ be the same as the value in `sosa:hasResult`." ;
@@ -96,17 +96,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     """
         ] ;
     sh:targetClass tern:Observation ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/most-dominant-species/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/most-dominant-species/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/most-dominant-species/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/most-dominant-species/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/most-dominant-species/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/most-dominant-species/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:most-dominant-species:site-visit>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "Observations following the Plot Description protocol are made in the context of a site visit." ;
@@ -128,17 +128,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/most-dominant-species/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/most-dominant-species/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/most-dominant-species/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/most-dominant-species/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/most-dominant-species/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/most-dominant-species/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:most-dominant-species:used-procedure>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description """IRI of procedure _MUST_ have the value `https://linked.data.gov.au/def/test/dawe-cv/1ff9e97c-3bdd-44c9-bdd3-401fa31c0b32`.
@@ -160,17 +160,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/most-dominant-species/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/most-dominant-species/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/most-dominant-species/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/most-dominant-species/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/most-dominant-species/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/most-dominant-species/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:most-dominant-species:value-type>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:class tern:IRI ;
@@ -190,17 +190,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/most-dominant-species/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/most-dominant-species/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/most-dominant-species/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/most-dominant-species/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/most-dominant-species/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/most-dominant-species/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:most-dominant-species:vocabulary>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description """IRI of `tern:vocabulary` in `sosa:hasResult` _MUST_ have the value `https://biodiversity.org.au/nsl/services/search/names`.
@@ -223,10 +223,10 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/most-dominant-species/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/most-dominant-species/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/most-dominant-species/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/most-dominant-species/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/most-dominant-species/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/most-dominant-species/shapes.ttl"^^xsd:anyURI ;
 .
 

--- a/shapes/plot-description/most-dominant-species/valid.ttl
+++ b/shapes/plot-description/most-dominant-species/valid.ttl
@@ -1,4 +1,3 @@
-
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX sosa: <http://www.w3.org/ns/sosa/>
 PREFIX tern: <https://w3id.org/tern/ontologies/tern/>

--- a/shapes/plot-description/outcrop-lithology/invalid.ttl
+++ b/shapes/plot-description/outcrop-lithology/invalid.ttl
@@ -1,4 +1,3 @@
-
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX sosa: <http://www.w3.org/ns/sosa/>

--- a/shapes/plot-description/outcrop-lithology/shapes.ttl
+++ b/shapes/plot-description/outcrop-lithology/shapes.ttl
@@ -1,17 +1,17 @@
-
 PREFIX dcterms: <http://purl.org/dc/terms/>
-PREFIX ns1: <urn:property:>
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX reg: <http://purl.org/linked-data/registry#>
 PREFIX sh: <http://www.w3.org/ns/shacl#>
 PREFIX sosa: <http://www.w3.org/ns/sosa/>
 PREFIX tern: <https://w3id.org/tern/ontologies/tern/>
+PREFIX urnc: <urn:class:>
+PREFIX urnp: <urn:property:>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <urn:shapes:plot-description:outcrop-lithology:feature-type>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "TERN's ecologists have determined the feature type is _land surface_, defined by the link:https://www.publish.csiro.au/book/5230/[Australian Soil and Land Survey Field Handbook]." ;
@@ -32,18 +32,18 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/outcrop-lithology/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/outcrop-lithology/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/outcrop-lithology/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/outcrop-lithology/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/outcrop-lithology/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/outcrop-lithology/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:outcrop-lithology:result-value>
     a
         sh:PropertyShape ,
-        <urn:class:Controlled> ,
-        <urn:class:Requirement> ;
+        urnc:Controlled ,
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "The value in `sosa:hasResult` _MUST_ be a value in `sh:in`, which is the soil lithology codes controlled vocabulary." ;
@@ -156,11 +156,11 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/outcrop-lithology/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/outcrop-lithology/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/outcrop-lithology/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/outcrop-lithology/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:query """
+    urnp:query """
             PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
             select ?values {
                     ?s skos:member ?values .
@@ -168,14 +168,14 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             }
 
     """ ;
-    ns1:sparqlEndpoint "https://graphdb.tern.org.au/repositories/dawe_vocabs_core" ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/outcrop-lithology/shapes.ttl"^^xsd:anyURI ;
+    urnp:sparqlEndpoint "https://graphdb.tern.org.au/repositories/dawe_vocabs_core" ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/outcrop-lithology/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:outcrop-lithology:simple-result>
     a
         sh:NodeShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "Value of `sosa:hasSimpleResult` _MUST_ be the same as the value in `sosa:hasResult`." ;
@@ -198,17 +198,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     """
         ] ;
     sh:targetClass tern:Observation ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/outcrop-lithology/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/outcrop-lithology/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/outcrop-lithology/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/outcrop-lithology/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/outcrop-lithology/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/outcrop-lithology/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:outcrop-lithology:site-visit>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "Observations following the Plot Description protocol are made in the context of a site visit." ;
@@ -230,17 +230,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/outcrop-lithology/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/outcrop-lithology/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/outcrop-lithology/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/outcrop-lithology/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/outcrop-lithology/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/outcrop-lithology/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:outcrop-lithology:used-procedure>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description """IRI of procedure _MUST_ have the value `https://linked.data.gov.au/def/test/dawe-cv/1ff9e97c-3bdd-44c9-bdd3-401fa31c0b32`.
@@ -262,17 +262,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/outcrop-lithology/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/outcrop-lithology/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/outcrop-lithology/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/outcrop-lithology/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/outcrop-lithology/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/outcrop-lithology/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:outcrop-lithology:value-type>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:class tern:IRI ;
@@ -292,17 +292,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/outcrop-lithology/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/outcrop-lithology/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/outcrop-lithology/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/outcrop-lithology/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/outcrop-lithology/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/outcrop-lithology/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:outcrop-lithology:vocabulary>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description """IRI of `tern:vocabulary` in `sosa:hasResult` _MUST_ have the value `https://linked.data.gov.au/def/test/dawe-cv/1d50eb79-685f-45ea-84b4-627154eddede`.
@@ -325,10 +325,10 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/outcrop-lithology/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/outcrop-lithology/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/outcrop-lithology/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/outcrop-lithology/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/outcrop-lithology/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/outcrop-lithology/shapes.ttl"^^xsd:anyURI ;
 .
 

--- a/shapes/plot-description/outcrop-lithology/valid.ttl
+++ b/shapes/plot-description/outcrop-lithology/valid.ttl
@@ -1,4 +1,3 @@
-
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX sosa: <http://www.w3.org/ns/sosa/>
 PREFIX tern: <https://w3id.org/tern/ontologies/tern/>

--- a/shapes/plot-description/second-most-dominant-species/invalid.ttl
+++ b/shapes/plot-description/second-most-dominant-species/invalid.ttl
@@ -1,4 +1,3 @@
-
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX sosa: <http://www.w3.org/ns/sosa/>

--- a/shapes/plot-description/second-most-dominant-species/shapes.ttl
+++ b/shapes/plot-description/second-most-dominant-species/shapes.ttl
@@ -1,17 +1,17 @@
-
 PREFIX dcterms: <http://purl.org/dc/terms/>
-PREFIX ns1: <urn:property:>
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX reg: <http://purl.org/linked-data/registry#>
 PREFIX sh: <http://www.w3.org/ns/shacl#>
 PREFIX sosa: <http://www.w3.org/ns/sosa/>
 PREFIX tern: <https://w3id.org/tern/ontologies/tern/>
+PREFIX urnc: <urn:class:>
+PREFIX urnp: <urn:property:>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <urn:shapes:plot-description:second-most-dominant-species:feature-type>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "TERN's ecologists have determined the feature type is _vegetation stratum_, defined by the link:https://www.publish.csiro.au/book/5230/[Australian Soil and Land Survey Field Handbook]." ;
@@ -32,17 +32,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/second-most-dominant-species/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/second-most-dominant-species/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/second-most-dominant-species/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/second-most-dominant-species/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/second-most-dominant-species/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/second-most-dominant-species/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:second-most-dominant-species:result-value>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "The value in `sosa:hasResult` _MUST_ match the pattern `biodiversity.org.au/boa/name/apni`, which is part of the searching result." ;
@@ -63,17 +63,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/second-most-dominant-species/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/second-most-dominant-species/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/second-most-dominant-species/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/second-most-dominant-species/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/second-most-dominant-species/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/second-most-dominant-species/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:second-most-dominant-species:simple-result>
     a
         sh:NodeShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "Value of `sosa:hasSimpleResult` _MUST_ be the same as the value in `sosa:hasResult`." ;
@@ -96,17 +96,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     """
         ] ;
     sh:targetClass tern:Observation ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/second-most-dominant-species/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/second-most-dominant-species/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/second-most-dominant-species/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/second-most-dominant-species/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/second-most-dominant-species/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/second-most-dominant-species/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:second-most-dominant-species:site-visit>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "Observations following the Plot Description protocol are made in the context of a site visit." ;
@@ -128,17 +128,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/second-most-dominant-species/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/second-most-dominant-species/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/second-most-dominant-species/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/second-most-dominant-species/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/second-most-dominant-species/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/second-most-dominant-species/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:second-most-dominant-species:used-procedure>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description """IRI of procedure _MUST_ have the value `https://linked.data.gov.au/def/test/dawe-cv/1ff9e97c-3bdd-44c9-bdd3-401fa31c0b32`.
@@ -160,17 +160,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/second-most-dominant-species/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/second-most-dominant-species/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/second-most-dominant-species/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/second-most-dominant-species/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/second-most-dominant-species/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/second-most-dominant-species/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:second-most-dominant-species:value-type>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:class tern:IRI ;
@@ -190,17 +190,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/second-most-dominant-species/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/second-most-dominant-species/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/second-most-dominant-species/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/second-most-dominant-species/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/second-most-dominant-species/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/second-most-dominant-species/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:second-most-dominant-species:vocabulary>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description """IRI of `tern:vocabulary` in `sosa:hasResult` _MUST_ have the value `https://biodiversity.org.au/nsl/services/search/names`.
@@ -223,10 +223,10 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/second-most-dominant-species/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/second-most-dominant-species/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/second-most-dominant-species/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/second-most-dominant-species/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/second-most-dominant-species/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/second-most-dominant-species/shapes.ttl"^^xsd:anyURI ;
 .
 

--- a/shapes/plot-description/second-most-dominant-species/valid.ttl
+++ b/shapes/plot-description/second-most-dominant-species/valid.ttl
@@ -1,4 +1,3 @@
-
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX sosa: <http://www.w3.org/ns/sosa/>
 PREFIX tern: <https://w3id.org/tern/ontologies/tern/>

--- a/shapes/plot-description/slope-type/invalid.ttl
+++ b/shapes/plot-description/slope-type/invalid.ttl
@@ -1,4 +1,3 @@
-
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX sosa: <http://www.w3.org/ns/sosa/>

--- a/shapes/plot-description/slope-type/shapes.ttl
+++ b/shapes/plot-description/slope-type/shapes.ttl
@@ -1,17 +1,17 @@
-
 PREFIX dcterms: <http://purl.org/dc/terms/>
-PREFIX ns1: <urn:property:>
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX reg: <http://purl.org/linked-data/registry#>
 PREFIX sh: <http://www.w3.org/ns/shacl#>
 PREFIX sosa: <http://www.w3.org/ns/sosa/>
 PREFIX tern: <https://w3id.org/tern/ontologies/tern/>
+PREFIX urnc: <urn:class:>
+PREFIX urnp: <urn:property:>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <urn:shapes:plot-description:slope-type:feature-type>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "TERN's ecologists have determined the feature type is _landform_, defined by the link:https://www.publish.csiro.au/book/5230/[Australian Soil and Land Survey Field Handbook]." ;
@@ -32,18 +32,18 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope-type/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope-type/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope-type/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope-type/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope-type/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope-type/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:slope-type:result-value>
     a
         sh:PropertyShape ,
-        <urn:class:Controlled> ,
-        <urn:class:Requirement> ;
+        urnc:Controlled ,
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "The value in `sosa:hasResult` _MUST_ be a value in `sh:in`, which is the Plot slope codes controlled vocabulary." ;
@@ -73,11 +73,11 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope-type/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope-type/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope-type/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope-type/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:query """
+    urnp:query """
             PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
             select ?values {
                     ?s skos:member ?values .
@@ -85,14 +85,14 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             }
 
     """ ;
-    ns1:sparqlEndpoint "https://graphdb.tern.org.au/repositories/dawe_vocabs_core" ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope-type/shapes.ttl"^^xsd:anyURI ;
+    urnp:sparqlEndpoint "https://graphdb.tern.org.au/repositories/dawe_vocabs_core" ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope-type/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:slope-type:simple-result>
     a
         sh:NodeShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "Value of `sosa:hasSimpleResult` _MUST_ be the same as the value in `sosa:hasResult`." ;
@@ -115,17 +115,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     """
         ] ;
     sh:targetClass tern:Observation ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope-type/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope-type/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope-type/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope-type/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope-type/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope-type/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:slope-type:site-visit>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "Observations following the Plot Description protocol are made in the context of a site visit." ;
@@ -147,17 +147,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope-type/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope-type/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope-type/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope-type/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope-type/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope-type/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:slope-type:used-procedure>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description """IRI of procedure _MUST_ have the value `https://linked.data.gov.au/def/test/dawe-cv/1ff9e97c-3bdd-44c9-bdd3-401fa31c0b32`.
@@ -179,17 +179,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope-type/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope-type/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope-type/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope-type/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope-type/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope-type/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:slope-type:value-type>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:class tern:IRI ;
@@ -209,17 +209,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope-type/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope-type/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope-type/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope-type/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope-type/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope-type/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:slope-type:vocabulary>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description """IRI of `tern:vocabulary` in `sosa:hasResult` _MUST_ have the value `https://linked.data.gov.au/def/test/dawe-cv/d893e669-c530-4bc3-a057-a5799ffcb5db`.
@@ -242,10 +242,10 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope-type/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope-type/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope-type/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope-type/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope-type/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope-type/shapes.ttl"^^xsd:anyURI ;
 .
 

--- a/shapes/plot-description/slope-type/valid.ttl
+++ b/shapes/plot-description/slope-type/valid.ttl
@@ -1,4 +1,3 @@
-
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX sosa: <http://www.w3.org/ns/sosa/>
 PREFIX tern: <https://w3id.org/tern/ontologies/tern/>

--- a/shapes/plot-description/slope/invalid.ttl
+++ b/shapes/plot-description/slope/invalid.ttl
@@ -1,4 +1,3 @@
-
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX sosa: <http://www.w3.org/ns/sosa/>

--- a/shapes/plot-description/slope/shapes.ttl
+++ b/shapes/plot-description/slope/shapes.ttl
@@ -1,17 +1,17 @@
-
 PREFIX dcterms: <http://purl.org/dc/terms/>
-PREFIX ns1: <urn:property:>
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX reg: <http://purl.org/linked-data/registry#>
 PREFIX sh: <http://www.w3.org/ns/shacl#>
 PREFIX sosa: <http://www.w3.org/ns/sosa/>
 PREFIX tern: <https://w3id.org/tern/ontologies/tern/>
+PREFIX urnc: <urn:class:>
+PREFIX urnp: <urn:property:>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <urn:shapes:plot-description:slope:feature-type>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "TERN's ecologists have determined the feature type is _landform_, defined by the link:https://www.publish.csiro.au/book/5230/[Australian Soil and Land Survey Field Handbook]." ;
@@ -32,17 +32,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:slope:simple-result>
     a
         sh:NodeShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "Value of `sosa:hasSimpleResult` _MUST_ be the same as the value in `sosa:hasResult`." ;
@@ -65,17 +65,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     """
         ] ;
     sh:targetClass tern:Observation ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:slope:site-visit>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "Observations following the Plot Description protocol are made in the context of a site visit." ;
@@ -97,17 +97,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:slope:unit-of-measure>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "Result value's unit of measure _MUST_ have the value `unit:DEG`." ;
@@ -128,17 +128,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:slope:used-procedure>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description """IRI of procedure _MUST_ have the value `https://linked.data.gov.au/def/test/dawe-cv/1ff9e97c-3bdd-44c9-bdd3-401fa31c0b32`.
@@ -160,17 +160,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:slope:value-range>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "Value _MUST_ be between 0 and 90 inclusive." ;
@@ -192,17 +192,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:slope:value-type>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:class tern:Float ;
@@ -222,10 +222,10 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope/shapes.ttl"^^xsd:anyURI ;
 .
 

--- a/shapes/plot-description/slope/valid.ttl
+++ b/shapes/plot-description/slope/valid.ttl
@@ -1,4 +1,3 @@
-
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX sosa: <http://www.w3.org/ns/sosa/>

--- a/shapes/plot-description/structural-formation/invalid.ttl
+++ b/shapes/plot-description/structural-formation/invalid.ttl
@@ -1,4 +1,3 @@
-
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX sosa: <http://www.w3.org/ns/sosa/>

--- a/shapes/plot-description/structural-formation/shapes.ttl
+++ b/shapes/plot-description/structural-formation/shapes.ttl
@@ -1,17 +1,17 @@
-
 PREFIX dcterms: <http://purl.org/dc/terms/>
-PREFIX ns1: <urn:property:>
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX reg: <http://purl.org/linked-data/registry#>
 PREFIX sh: <http://www.w3.org/ns/shacl#>
 PREFIX sosa: <http://www.w3.org/ns/sosa/>
 PREFIX tern: <https://w3id.org/tern/ontologies/tern/>
+PREFIX urnc: <urn:class:>
+PREFIX urnp: <urn:property:>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <urn:shapes:plot-description:structural-formation:feature-type>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "TERN's ecologists have determined the feature type is _vegetation_, defined by the link:https://www.publish.csiro.au/book/5230/[Australian Soil and Land Survey Field Handbook]." ;
@@ -32,18 +32,18 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/structural-formation/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/structural-formation/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/structural-formation/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/structural-formation/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/structural-formation/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/structural-formation/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:structural-formation:result-value>
     a
         sh:PropertyShape ,
-        <urn:class:Controlled> ,
-        <urn:class:Requirement> ;
+        urnc:Controlled ,
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "The value in `sosa:hasResult` _MUST_ be a value in `sh:in`, which is the Vegetation structural formation codes controlled vocabulary." ;
@@ -155,11 +155,11 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/structural-formation/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/structural-formation/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/structural-formation/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/structural-formation/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:query """
+    urnp:query """
             PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
             select ?values {
                     ?s skos:member ?values .
@@ -167,14 +167,14 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             }
 
     """ ;
-    ns1:sparqlEndpoint "https://graphdb.tern.org.au/repositories/dawe_vocabs_core" ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/structural-formation/shapes.ttl"^^xsd:anyURI ;
+    urnp:sparqlEndpoint "https://graphdb.tern.org.au/repositories/dawe_vocabs_core" ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/structural-formation/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:structural-formation:simple-result>
     a
         sh:NodeShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "Value of `sosa:hasSimpleResult` _MUST_ be the same as the value in `sosa:hasResult`." ;
@@ -197,17 +197,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     """
         ] ;
     sh:targetClass tern:Observation ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/structural-formation/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/structural-formation/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/structural-formation/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/structural-formation/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/structural-formation/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/structural-formation/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:structural-formation:site-visit>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "Observations following the Plot Description protocol are made in the context of a site visit." ;
@@ -229,17 +229,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/structural-formation/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/structural-formation/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/structural-formation/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/structural-formation/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/structural-formation/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/structural-formation/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:structural-formation:used-procedure>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description """IRI of procedure _MUST_ have the value `https://linked.data.gov.au/def/test/dawe-cv/1ff9e97c-3bdd-44c9-bdd3-401fa31c0b32`.
@@ -261,17 +261,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/structural-formation/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/structural-formation/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/structural-formation/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/structural-formation/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/structural-formation/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/structural-formation/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:structural-formation:value-type>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:class tern:IRI ;
@@ -291,17 +291,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/structural-formation/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/structural-formation/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/structural-formation/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/structural-formation/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/structural-formation/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/structural-formation/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:structural-formation:vocabulary>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description """IRI of `tern:vocabulary` in `sosa:hasResult` _MUST_ have the value `https://linked.data.gov.au/def/test/dawe-cv/6e9baf51-566e-4a5d-93c4-a6e097dc364d`.
@@ -324,10 +324,10 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/structural-formation/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/structural-formation/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/structural-formation/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/structural-formation/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/structural-formation/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/structural-formation/shapes.ttl"^^xsd:anyURI ;
 .
 

--- a/shapes/plot-description/structural-formation/valid.ttl
+++ b/shapes/plot-description/structural-formation/valid.ttl
@@ -1,4 +1,3 @@
-
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX sosa: <http://www.w3.org/ns/sosa/>
 PREFIX tern: <https://w3id.org/tern/ontologies/tern/>

--- a/shapes/plot-description/surface-strew-lithology/invalid.ttl
+++ b/shapes/plot-description/surface-strew-lithology/invalid.ttl
@@ -1,4 +1,3 @@
-
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX sosa: <http://www.w3.org/ns/sosa/>

--- a/shapes/plot-description/surface-strew-lithology/shapes.ttl
+++ b/shapes/plot-description/surface-strew-lithology/shapes.ttl
@@ -1,17 +1,17 @@
-
 PREFIX dcterms: <http://purl.org/dc/terms/>
-PREFIX ns1: <urn:property:>
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX reg: <http://purl.org/linked-data/registry#>
 PREFIX sh: <http://www.w3.org/ns/shacl#>
 PREFIX sosa: <http://www.w3.org/ns/sosa/>
 PREFIX tern: <https://w3id.org/tern/ontologies/tern/>
+PREFIX urnc: <urn:class:>
+PREFIX urnp: <urn:property:>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <urn:shapes:plot-description:surface-strew-lithology:feature-type>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "TERN's ecologists have determined the feature type is _land surface_, defined by the link:https://www.publish.csiro.au/book/5230/[Australian Soil and Land Survey Field Handbook]." ;
@@ -32,18 +32,18 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-lithology/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-lithology/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-lithology/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-lithology/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-lithology/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-lithology/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:surface-strew-lithology:result-value>
     a
         sh:PropertyShape ,
-        <urn:class:Controlled> ,
-        <urn:class:Requirement> ;
+        urnc:Controlled ,
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "The value in `sosa:hasResult` _MUST_ be a value in `sh:in`, which is the soil lithology codes controlled vocabulary." ;
@@ -156,11 +156,11 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-lithology/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-lithology/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-lithology/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-lithology/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:query """
+    urnp:query """
             PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
             select ?values {
                     ?s skos:member ?values .
@@ -168,14 +168,14 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             }
 
     """ ;
-    ns1:sparqlEndpoint "https://graphdb.tern.org.au/repositories/dawe_vocabs_core" ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-lithology/shapes.ttl"^^xsd:anyURI ;
+    urnp:sparqlEndpoint "https://graphdb.tern.org.au/repositories/dawe_vocabs_core" ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-lithology/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:surface-strew-lithology:simple-result>
     a
         sh:NodeShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "Value of `sosa:hasSimpleResult` _MUST_ be the same as the value in `sosa:hasResult`." ;
@@ -198,17 +198,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     """
         ] ;
     sh:targetClass tern:Observation ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-lithology/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-lithology/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-lithology/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-lithology/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-lithology/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-lithology/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:surface-strew-lithology:site-visit>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "Observations following the Plot Description protocol are made in the context of a site visit." ;
@@ -230,17 +230,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-lithology/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-lithology/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-lithology/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-lithology/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-lithology/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-lithology/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:surface-strew-lithology:used-procedure>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description """IRI of procedure _MUST_ have the value `https://linked.data.gov.au/def/test/dawe-cv/1ff9e97c-3bdd-44c9-bdd3-401fa31c0b32`.
@@ -262,17 +262,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-lithology/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-lithology/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-lithology/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-lithology/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-lithology/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-lithology/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:surface-strew-lithology:value-type>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:class tern:IRI ;
@@ -292,17 +292,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-lithology/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-lithology/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-lithology/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-lithology/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-lithology/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-lithology/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:surface-strew-lithology:vocabulary>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description """IRI of `tern:vocabulary` in `sosa:hasResult` _MUST_ have the value `https://linked.data.gov.au/def/test/dawe-cv/1d50eb79-685f-45ea-84b4-627154eddede`.
@@ -325,10 +325,10 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-lithology/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-lithology/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-lithology/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-lithology/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-lithology/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-lithology/shapes.ttl"^^xsd:anyURI ;
 .
 

--- a/shapes/plot-description/surface-strew-lithology/valid.ttl
+++ b/shapes/plot-description/surface-strew-lithology/valid.ttl
@@ -1,4 +1,3 @@
-
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX sosa: <http://www.w3.org/ns/sosa/>
 PREFIX tern: <https://w3id.org/tern/ontologies/tern/>

--- a/shapes/plot-description/surface-strew-size/invalid.ttl
+++ b/shapes/plot-description/surface-strew-size/invalid.ttl
@@ -1,4 +1,3 @@
-
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX sosa: <http://www.w3.org/ns/sosa/>

--- a/shapes/plot-description/surface-strew-size/shapes.ttl
+++ b/shapes/plot-description/surface-strew-size/shapes.ttl
@@ -1,17 +1,17 @@
-
 PREFIX dcterms: <http://purl.org/dc/terms/>
-PREFIX ns1: <urn:property:>
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX reg: <http://purl.org/linked-data/registry#>
 PREFIX sh: <http://www.w3.org/ns/shacl#>
 PREFIX sosa: <http://www.w3.org/ns/sosa/>
 PREFIX tern: <https://w3id.org/tern/ontologies/tern/>
+PREFIX urnc: <urn:class:>
+PREFIX urnp: <urn:property:>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <urn:shapes:plot-description:surface-strew-size:feature-type>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "TERN's ecologists have determined the feature type is _land surface_, defined by the link:https://www.publish.csiro.au/book/5230/[Australian Soil and Land Survey Field Handbook]." ;
@@ -32,18 +32,18 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-size/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-size/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-size/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-size/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-size/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-size/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:surface-strew-size:result-value>
     a
         sh:PropertyShape ,
-        <urn:class:Controlled> ,
-        <urn:class:Requirement> ;
+        urnc:Controlled ,
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "The value in `sosa:hasResult` _MUST_ be a value in `sh:in`, which is the Soil surface strew size codes controlled vocabulary." ;
@@ -69,11 +69,11 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-size/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-size/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-size/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-size/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:query """
+    urnp:query """
             PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
             select ?values {
                     ?s skos:member ?values .
@@ -81,14 +81,14 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             }
 
     """ ;
-    ns1:sparqlEndpoint "https://graphdb.tern.org.au/repositories/dawe_vocabs_core" ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-size/shapes.ttl"^^xsd:anyURI ;
+    urnp:sparqlEndpoint "https://graphdb.tern.org.au/repositories/dawe_vocabs_core" ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-size/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:surface-strew-size:simple-result>
     a
         sh:NodeShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "Value of `sosa:hasSimpleResult` _MUST_ be the same as the value in `sosa:hasResult`." ;
@@ -111,17 +111,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     """
         ] ;
     sh:targetClass tern:Observation ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-size/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-size/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-size/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-size/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-size/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-size/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:surface-strew-size:site-visit>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description "Observations following the Plot Description protocol are made in the context of a site visit." ;
@@ -143,17 +143,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-size/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-size/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-size/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-size/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-size/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-size/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:surface-strew-size:used-procedure>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description """IRI of procedure _MUST_ have the value `https://linked.data.gov.au/def/test/dawe-cv/1ff9e97c-3bdd-44c9-bdd3-401fa31c0b32`.
@@ -175,17 +175,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-size/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-size/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-size/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-size/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-size/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-size/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:surface-strew-size:value-type>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:class tern:IRI ;
@@ -205,17 +205,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-size/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-size/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-size/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-size/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-size/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-size/shapes.ttl"^^xsd:anyURI ;
 .
 
 <urn:shapes:plot-description:surface-strew-size:vocabulary>
     a
         sh:PropertyShape ,
-        <urn:class:Requirement> ;
+        urnc:Requirement ;
     dcterms:source "TERN Ecosystem Surveillance Ecological Monitoring Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:description """IRI of `tern:vocabulary` in `sosa:hasResult` _MUST_ have the value `https://linked.data.gov.au/def/test/dawe-cv/3b25ce0f-9eb7-4d2d-97ce-143858cfd4d4`.
@@ -238,10 +238,10 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             }
     """
         ] ;
-    ns1:examples [
-            ns1:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-size/invalid.ttl"^^xsd:anyURI ;
-            ns1:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-size/valid.ttl"^^xsd:anyURI
+    urnp:examples [
+            urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-size/invalid.ttl"^^xsd:anyURI ;
+            urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-size/valid.ttl"^^xsd:anyURI
         ] ;
-    ns1:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-size/shapes.ttl"^^xsd:anyURI ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-size/shapes.ttl"^^xsd:anyURI ;
 .
 

--- a/shapes/plot-description/surface-strew-size/valid.ttl
+++ b/shapes/plot-description/surface-strew-size/valid.ttl
@@ -1,4 +1,3 @@
-
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX sosa: <http://www.w3.org/ns/sosa/>
 PREFIX tern: <https://w3id.org/tern/ontologies/tern/>


### PR DESCRIPTION
`ontotools` is upgraded to `0.6.2`, with 2 new namespaces created - `URNC` (<urn:class>) and `URNP` (<urn:property>). They are used in SHACL files, invalid examples, and also metadata files from `dawe-rlp-vocabs`.