### PR TITLE
Added URI to example files nodes for `plot description` and `cover`

### DIFF
--- a/shapes/cover/cover-full-protocol-shapes/field-species-name/shapes.ttl
+++ b/shapes/cover/cover-full-protocol-shapes/field-species-name/shapes.ttl
@@ -31,7 +31,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                 sosa:hasResult ?this .
         }"""
         ] ;
-    urnp:examples _:n47feb8c2eb0e4be1b650cd114bf4256db2 ;
+    urnp:examples <urn:shapes:cover-full:field-species-name:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-full/field-species-name/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -60,7 +60,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n47feb8c2eb0e4be1b650cd114bf4256db2 ;
+    urnp:examples <urn:shapes:cover-full:field-species-name:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-full/field-species-name/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -92,7 +92,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     """
         ] ;
     sh:targetClass tern:Observation ;
-    urnp:examples _:n47feb8c2eb0e4be1b650cd114bf4256db2 ;
+    urnp:examples <urn:shapes:cover-full:field-species-name:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-full/field-species-name/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -122,7 +122,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n47feb8c2eb0e4be1b650cd114bf4256db2 ;
+    urnp:examples <urn:shapes:cover-full:field-species-name:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-full/field-species-name/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -153,7 +153,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n47feb8c2eb0e4be1b650cd114bf4256db2 ;
+    urnp:examples <urn:shapes:cover-full:field-species-name:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-full/field-species-name/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -182,11 +182,11 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n47feb8c2eb0e4be1b650cd114bf4256db2 ;
+    urnp:examples <urn:shapes:cover-full:field-species-name:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-full/field-species-name/shapes.ttl"^^xsd:anyURI ;
 .
 
-_:n47feb8c2eb0e4be1b650cd114bf4256db2
+<urn:shapes:cover-full:field-species-name:examples>
     urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-full/field-species-name/invalid.ttl"^^xsd:anyURI ;
     urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-full/field-species-name/valid.ttl"^^xsd:anyURI ;
 .

--- a/shapes/cover/cover-full-protocol-shapes/growth-form/shapes.ttl
+++ b/shapes/cover/cover-full-protocol-shapes/growth-form/shapes.ttl
@@ -32,7 +32,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n6f500e1a986944d3af4d5f336efdc27cb2 ;
+    urnp:examples <urn:shapes:cover-full:growth-form:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-full/growth-form/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -89,7 +89,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                 sosa:hasResult ?this .
         }"""
         ] ;
-    urnp:examples _:n6f500e1a986944d3af4d5f336efdc27cb2 ;
+    urnp:examples <urn:shapes:cover-full:growth-form:examples> ;
     urnp:query """
         PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
         select ?values {
@@ -130,7 +130,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     """
         ] ;
     sh:targetClass tern:Observation ;
-    urnp:examples _:n6f500e1a986944d3af4d5f336efdc27cb2 ;
+    urnp:examples <urn:shapes:cover-full:growth-form:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-full/growth-form/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -160,7 +160,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n6f500e1a986944d3af4d5f336efdc27cb2 ;
+    urnp:examples <urn:shapes:cover-full:growth-form:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-full/growth-form/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -191,7 +191,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n6f500e1a986944d3af4d5f336efdc27cb2 ;
+    urnp:examples <urn:shapes:cover-full:growth-form:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-full/growth-form/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -220,7 +220,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n6f500e1a986944d3af4d5f336efdc27cb2 ;
+    urnp:examples <urn:shapes:cover-full:growth-form:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-full/growth-form/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -250,11 +250,11 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                 sosa:hasResult ?this .
         }"""
         ] ;
-    urnp:examples _:n6f500e1a986944d3af4d5f336efdc27cb2 ;
+    urnp:examples <urn:shapes:cover-full:growth-form:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-full/growth-form/shapes.ttl"^^xsd:anyURI ;
 .
 
-_:n6f500e1a986944d3af4d5f336efdc27cb2
+<urn:shapes:cover-full:growth-form:examples>
     urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-full/growth-form/invalid.ttl"^^xsd:anyURI ;
     urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-full/growth-form/valid.ttl"^^xsd:anyURI ;
 .

--- a/shapes/cover/cover-full-protocol-shapes/in-canopy-sky/shapes.ttl
+++ b/shapes/cover/cover-full-protocol-shapes/in-canopy-sky/shapes.ttl
@@ -31,7 +31,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                 sosa:hasResult ?this .
         }"""
         ] ;
-    urnp:examples _:n8fe35673c65a45d19c39b2710d3538bcb2 ;
+    urnp:examples <urn:shapes:cover-full:in-canopy-sky:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-full/in-canopy-sky/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -60,7 +60,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n8fe35673c65a45d19c39b2710d3538bcb2 ;
+    urnp:examples <urn:shapes:cover-full:in-canopy-sky:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-full/in-canopy-sky/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -92,7 +92,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     """
         ] ;
     sh:targetClass tern:Observation ;
-    urnp:examples _:n8fe35673c65a45d19c39b2710d3538bcb2 ;
+    urnp:examples <urn:shapes:cover-full:in-canopy-sky:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-full/in-canopy-sky/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -122,7 +122,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n8fe35673c65a45d19c39b2710d3538bcb2 ;
+    urnp:examples <urn:shapes:cover-full:in-canopy-sky:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-full/in-canopy-sky/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -153,7 +153,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n8fe35673c65a45d19c39b2710d3538bcb2 ;
+    urnp:examples <urn:shapes:cover-full:in-canopy-sky:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-full/in-canopy-sky/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -182,11 +182,11 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n8fe35673c65a45d19c39b2710d3538bcb2 ;
+    urnp:examples <urn:shapes:cover-full:in-canopy-sky:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-full/in-canopy-sky/shapes.ttl"^^xsd:anyURI ;
 .
 
-_:n8fe35673c65a45d19c39b2710d3538bcb2
+<urn:shapes:cover-full:in-canopy-sky:examples>
     urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-full/in-canopy-sky/invalid.ttl"^^xsd:anyURI ;
     urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-full/in-canopy-sky/valid.ttl"^^xsd:anyURI ;
 .

--- a/shapes/cover/cover-full-protocol-shapes/substrate-type/shapes.ttl
+++ b/shapes/cover/cover-full-protocol-shapes/substrate-type/shapes.ttl
@@ -32,7 +32,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n351a56a9adc54fd7946c84563caaccc9b2 ;
+    urnp:examples <urn:shapes:cover-full:substrate-type:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-full/substrate-type/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -77,7 +77,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                 sosa:hasResult ?this .
         }"""
         ] ;
-    urnp:examples _:n351a56a9adc54fd7946c84563caaccc9b2 ;
+    urnp:examples <urn:shapes:cover-full:substrate-type:examples> ;
     urnp:query """
         PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
         select ?values {
@@ -118,7 +118,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     """
         ] ;
     sh:targetClass tern:Observation ;
-    urnp:examples _:n351a56a9adc54fd7946c84563caaccc9b2 ;
+    urnp:examples <urn:shapes:cover-full:substrate-type:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-full/substrate-type/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -148,7 +148,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n351a56a9adc54fd7946c84563caaccc9b2 ;
+    urnp:examples <urn:shapes:cover-full:substrate-type:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-full/substrate-type/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -179,7 +179,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n351a56a9adc54fd7946c84563caaccc9b2 ;
+    urnp:examples <urn:shapes:cover-full:substrate-type:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-full/substrate-type/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -208,7 +208,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n351a56a9adc54fd7946c84563caaccc9b2 ;
+    urnp:examples <urn:shapes:cover-full:substrate-type:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-full/substrate-type/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -238,11 +238,11 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                 sosa:hasResult ?this .
         }"""
         ] ;
-    urnp:examples _:n351a56a9adc54fd7946c84563caaccc9b2 ;
+    urnp:examples <urn:shapes:cover-full:substrate-type:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-full/substrate-type/shapes.ttl"^^xsd:anyURI ;
 .
 
-_:n351a56a9adc54fd7946c84563caaccc9b2
+<urn:shapes:cover-full:substrate-type:examples>
     urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-full/substrate-type/invalid.ttl"^^xsd:anyURI ;
     urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-full/substrate-type/valid.ttl"^^xsd:anyURI ;
 .

--- a/shapes/cover/cover-full-protocol-shapes/uppermost-height/shapes.ttl
+++ b/shapes/cover/cover-full-protocol-shapes/uppermost-height/shapes.ttl
@@ -33,7 +33,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n142bceca780847b48cfa1aaa6ea27b2fb2 ;
+    urnp:examples <urn:shapes:cover-full:uppermost-height:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-full/uppermost-height/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -65,7 +65,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     """
         ] ;
     sh:targetClass tern:Observation ;
-    urnp:examples _:n142bceca780847b48cfa1aaa6ea27b2fb2 ;
+    urnp:examples <urn:shapes:cover-full:uppermost-height:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-full/uppermost-height/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -95,7 +95,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n142bceca780847b48cfa1aaa6ea27b2fb2 ;
+    urnp:examples <urn:shapes:cover-full:uppermost-height:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-full/uppermost-height/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -123,7 +123,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                 sosa:hasResult ?this .
         }"""
         ] ;
-    urnp:examples _:n142bceca780847b48cfa1aaa6ea27b2fb2 ;
+    urnp:examples <urn:shapes:cover-full:uppermost-height:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-full/uppermost-height/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -154,7 +154,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n142bceca780847b48cfa1aaa6ea27b2fb2 ;
+    urnp:examples <urn:shapes:cover-full:uppermost-height:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-full/uppermost-height/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -183,7 +183,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                 sosa:hasResult ?this .
         }"""
         ] ;
-    urnp:examples _:n142bceca780847b48cfa1aaa6ea27b2fb2 ;
+    urnp:examples <urn:shapes:cover-full:uppermost-height:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-full/uppermost-height/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -212,11 +212,11 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n142bceca780847b48cfa1aaa6ea27b2fb2 ;
+    urnp:examples <urn:shapes:cover-full:uppermost-height:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-full/uppermost-height/shapes.ttl"^^xsd:anyURI ;
 .
 
-_:n142bceca780847b48cfa1aaa6ea27b2fb2
+<urn:shapes:cover-full:uppermost-height:examples>
     urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-full/uppermost-height/invalid.ttl"^^xsd:anyURI ;
     urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-full/uppermost-height/valid.ttl"^^xsd:anyURI ;
 .

--- a/shapes/cover/cover-lite-protocol-shapes/field-species-name/shapes.ttl
+++ b/shapes/cover/cover-lite-protocol-shapes/field-species-name/shapes.ttl
@@ -31,7 +31,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                 sosa:hasResult ?this .
         }"""
         ] ;
-    urnp:examples _:ncca59003e3664b8ca6627833a430e7e7b2 ;
+    urnp:examples <urn:shapes:cover-lite:field-species-name:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-lite/field-species-name/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -60,7 +60,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:ncca59003e3664b8ca6627833a430e7e7b2 ;
+    urnp:examples <urn:shapes:cover-lite:field-species-name:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-lite/field-species-name/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -92,7 +92,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     """
         ] ;
     sh:targetClass tern:Observation ;
-    urnp:examples _:ncca59003e3664b8ca6627833a430e7e7b2 ;
+    urnp:examples <urn:shapes:cover-lite:field-species-name:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-lite/field-species-name/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -122,7 +122,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:ncca59003e3664b8ca6627833a430e7e7b2 ;
+    urnp:examples <urn:shapes:cover-lite:field-species-name:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-lite/field-species-name/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -153,7 +153,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:ncca59003e3664b8ca6627833a430e7e7b2 ;
+    urnp:examples <urn:shapes:cover-lite:field-species-name:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-lite/field-species-name/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -182,11 +182,11 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:ncca59003e3664b8ca6627833a430e7e7b2 ;
+    urnp:examples <urn:shapes:cover-lite:field-species-name:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-lite/field-species-name/shapes.ttl"^^xsd:anyURI ;
 .
 
-_:ncca59003e3664b8ca6627833a430e7e7b2
+<urn:shapes:cover-lite:field-species-name:examples>
     urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-lite/field-species-name/invalid.ttl"^^xsd:anyURI ;
     urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-lite/field-species-name/valid.ttl"^^xsd:anyURI ;
 .

--- a/shapes/cover/cover-lite-protocol-shapes/growth-form/shapes.ttl
+++ b/shapes/cover/cover-lite-protocol-shapes/growth-form/shapes.ttl
@@ -32,7 +32,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n77bf066c9a90494784a1e90ee24714e7b2 ;
+    urnp:examples <urn:shapes:cover-lite:growth-form:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-lite/growth-form/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -89,7 +89,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                 sosa:hasResult ?this .
         }"""
         ] ;
-    urnp:examples _:n77bf066c9a90494784a1e90ee24714e7b2 ;
+    urnp:examples <urn:shapes:cover-lite:growth-form:examples> ;
     urnp:query """
         PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
         select ?values {
@@ -130,7 +130,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     """
         ] ;
     sh:targetClass tern:Observation ;
-    urnp:examples _:n77bf066c9a90494784a1e90ee24714e7b2 ;
+    urnp:examples <urn:shapes:cover-lite:growth-form:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-lite/growth-form/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -160,7 +160,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n77bf066c9a90494784a1e90ee24714e7b2 ;
+    urnp:examples <urn:shapes:cover-lite:growth-form:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-lite/growth-form/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -191,7 +191,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n77bf066c9a90494784a1e90ee24714e7b2 ;
+    urnp:examples <urn:shapes:cover-lite:growth-form:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-lite/growth-form/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -220,7 +220,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n77bf066c9a90494784a1e90ee24714e7b2 ;
+    urnp:examples <urn:shapes:cover-lite:growth-form:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-lite/growth-form/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -250,11 +250,11 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                 sosa:hasResult ?this .
         }"""
         ] ;
-    urnp:examples _:n77bf066c9a90494784a1e90ee24714e7b2 ;
+    urnp:examples <urn:shapes:cover-lite:growth-form:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-lite/growth-form/shapes.ttl"^^xsd:anyURI ;
 .
 
-_:n77bf066c9a90494784a1e90ee24714e7b2
+<urn:shapes:cover-lite:growth-form:examples>
     urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-lite/growth-form/invalid.ttl"^^xsd:anyURI ;
     urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-lite/growth-form/valid.ttl"^^xsd:anyURI ;
 .

--- a/shapes/cover/cover-lite-protocol-shapes/in-canopy-sky/shapes.ttl
+++ b/shapes/cover/cover-lite-protocol-shapes/in-canopy-sky/shapes.ttl
@@ -31,7 +31,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                 sosa:hasResult ?this .
         }"""
         ] ;
-    urnp:examples _:n52373ec3333744f1a4a02dd88578fde2b2 ;
+    urnp:examples <urn:shapes:cover-lite:in-canopy-sky:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-lite/in-canopy-sky/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -60,7 +60,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n52373ec3333744f1a4a02dd88578fde2b2 ;
+    urnp:examples <urn:shapes:cover-lite:in-canopy-sky:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-lite/in-canopy-sky/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -92,7 +92,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     """
         ] ;
     sh:targetClass tern:Observation ;
-    urnp:examples _:n52373ec3333744f1a4a02dd88578fde2b2 ;
+    urnp:examples <urn:shapes:cover-lite:in-canopy-sky:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-lite/in-canopy-sky/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -122,7 +122,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n52373ec3333744f1a4a02dd88578fde2b2 ;
+    urnp:examples <urn:shapes:cover-lite:in-canopy-sky:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-lite/in-canopy-sky/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -153,7 +153,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n52373ec3333744f1a4a02dd88578fde2b2 ;
+    urnp:examples <urn:shapes:cover-lite:in-canopy-sky:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-lite/in-canopy-sky/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -182,11 +182,11 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n52373ec3333744f1a4a02dd88578fde2b2 ;
+    urnp:examples <urn:shapes:cover-lite:in-canopy-sky:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-lite/in-canopy-sky/shapes.ttl"^^xsd:anyURI ;
 .
 
-_:n52373ec3333744f1a4a02dd88578fde2b2
+<urn:shapes:cover-lite:in-canopy-sky:examples>
     urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-lite/in-canopy-sky/invalid.ttl"^^xsd:anyURI ;
     urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-lite/in-canopy-sky/valid.ttl"^^xsd:anyURI ;
 .

--- a/shapes/cover/cover-lite-protocol-shapes/substrate-type/shapes.ttl
+++ b/shapes/cover/cover-lite-protocol-shapes/substrate-type/shapes.ttl
@@ -32,7 +32,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n0a3550e18d6c4ca5a69861b417724e71b2 ;
+    urnp:examples <urn:shapes:cover-lite:substrate-type:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-lite/substrate-type/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -77,7 +77,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                 sosa:hasResult ?this .
         }"""
         ] ;
-    urnp:examples _:n0a3550e18d6c4ca5a69861b417724e71b2 ;
+    urnp:examples <urn:shapes:cover-lite:substrate-type:examples> ;
     urnp:query """
         PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
         select ?values {
@@ -118,7 +118,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     """
         ] ;
     sh:targetClass tern:Observation ;
-    urnp:examples _:n0a3550e18d6c4ca5a69861b417724e71b2 ;
+    urnp:examples <urn:shapes:cover-lite:substrate-type:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-lite/substrate-type/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -148,7 +148,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n0a3550e18d6c4ca5a69861b417724e71b2 ;
+    urnp:examples <urn:shapes:cover-lite:substrate-type:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-lite/substrate-type/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -179,7 +179,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n0a3550e18d6c4ca5a69861b417724e71b2 ;
+    urnp:examples <urn:shapes:cover-lite:substrate-type:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-lite/substrate-type/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -208,7 +208,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n0a3550e18d6c4ca5a69861b417724e71b2 ;
+    urnp:examples <urn:shapes:cover-lite:substrate-type:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-lite/substrate-type/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -238,11 +238,11 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                 sosa:hasResult ?this .
         }"""
         ] ;
-    urnp:examples _:n0a3550e18d6c4ca5a69861b417724e71b2 ;
+    urnp:examples <urn:shapes:cover-lite:substrate-type:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-lite/substrate-type/shapes.ttl"^^xsd:anyURI ;
 .
 
-_:n0a3550e18d6c4ca5a69861b417724e71b2
+<urn:shapes:cover-lite:substrate-type:examples>
     urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-lite/substrate-type/invalid.ttl"^^xsd:anyURI ;
     urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-lite/substrate-type/valid.ttl"^^xsd:anyURI ;
 .

--- a/shapes/cover/cover-lite-protocol-shapes/uppermost-height/shapes.ttl
+++ b/shapes/cover/cover-lite-protocol-shapes/uppermost-height/shapes.ttl
@@ -33,7 +33,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:nad4f3f68fa214bd68f5d101b9b708201b2 ;
+    urnp:examples <urn:shapes:cover-lite:uppermost-height:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-lite/uppermost-height/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -65,7 +65,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     """
         ] ;
     sh:targetClass tern:Observation ;
-    urnp:examples _:nad4f3f68fa214bd68f5d101b9b708201b2 ;
+    urnp:examples <urn:shapes:cover-lite:uppermost-height:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-lite/uppermost-height/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -95,7 +95,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:nad4f3f68fa214bd68f5d101b9b708201b2 ;
+    urnp:examples <urn:shapes:cover-lite:uppermost-height:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-lite/uppermost-height/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -123,7 +123,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                 sosa:hasResult ?this .
         }"""
         ] ;
-    urnp:examples _:nad4f3f68fa214bd68f5d101b9b708201b2 ;
+    urnp:examples <urn:shapes:cover-lite:uppermost-height:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-lite/uppermost-height/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -154,7 +154,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:nad4f3f68fa214bd68f5d101b9b708201b2 ;
+    urnp:examples <urn:shapes:cover-lite:uppermost-height:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-lite/uppermost-height/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -183,7 +183,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                 sosa:hasResult ?this .
         }"""
         ] ;
-    urnp:examples _:nad4f3f68fa214bd68f5d101b9b708201b2 ;
+    urnp:examples <urn:shapes:cover-lite:uppermost-height:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-lite/uppermost-height/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -212,11 +212,11 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:nad4f3f68fa214bd68f5d101b9b708201b2 ;
+    urnp:examples <urn:shapes:cover-lite:uppermost-height:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-lite/uppermost-height/shapes.ttl"^^xsd:anyURI ;
 .
 
-_:nad4f3f68fa214bd68f5d101b9b708201b2
+<urn:shapes:cover-lite:uppermost-height:examples>
     urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-lite/uppermost-height/invalid.ttl"^^xsd:anyURI ;
     urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/cover/cover-lite/uppermost-height/valid.ttl"^^xsd:anyURI ;
 .

--- a/shapes/plot-description-protocol-shapes/aspect/shapes.ttl
+++ b/shapes/plot-description-protocol-shapes/aspect/shapes.ttl
@@ -33,7 +33,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n0a8ac03095eb44b599c4f444cf01cab9b2 ;
+    urnp:examples <urn:shapes:plot-description:aspect:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/aspect/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -65,7 +65,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     """
         ] ;
     sh:targetClass tern:Observation ;
-    urnp:examples _:n0a8ac03095eb44b599c4f444cf01cab9b2 ;
+    urnp:examples <urn:shapes:plot-description:aspect:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/aspect/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -95,7 +95,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n0a8ac03095eb44b599c4f444cf01cab9b2 ;
+    urnp:examples <urn:shapes:plot-description:aspect:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/aspect/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -123,7 +123,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                 sosa:hasResult ?this .
         }"""
         ] ;
-    urnp:examples _:n0a8ac03095eb44b599c4f444cf01cab9b2 ;
+    urnp:examples <urn:shapes:plot-description:aspect:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/aspect/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -154,7 +154,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n0a8ac03095eb44b599c4f444cf01cab9b2 ;
+    urnp:examples <urn:shapes:plot-description:aspect:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/aspect/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -184,7 +184,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                 sosa:hasResult ?this .
         }"""
         ] ;
-    urnp:examples _:n0a8ac03095eb44b599c4f444cf01cab9b2 ;
+    urnp:examples <urn:shapes:plot-description:aspect:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/aspect/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -213,11 +213,11 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n0a8ac03095eb44b599c4f444cf01cab9b2 ;
+    urnp:examples <urn:shapes:plot-description:aspect:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/aspect/shapes.ttl"^^xsd:anyURI ;
 .
 
-_:n0a8ac03095eb44b599c4f444cf01cab9b2
+<urn:shapes:plot-description:aspect:examples>
     urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/aspect/invalid.ttl"^^xsd:anyURI ;
     urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/aspect/valid.ttl"^^xsd:anyURI ;
 .

--- a/shapes/plot-description-protocol-shapes/climatic-condition/shapes.ttl
+++ b/shapes/plot-description-protocol-shapes/climatic-condition/shapes.ttl
@@ -32,7 +32,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:nc5fd07d2008e48268d06d8504e740453b2 ;
+    urnp:examples <urn:shapes:plot-description:climatic-condition:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/climatic-condition/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -64,7 +64,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                 sosa:hasResult ?this .
         }"""
         ] ;
-    urnp:examples _:nc5fd07d2008e48268d06d8504e740453b2 ;
+    urnp:examples <urn:shapes:plot-description:climatic-condition:examples> ;
     urnp:query """
         PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
         select ?values {
@@ -105,7 +105,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     """
         ] ;
     sh:targetClass tern:Observation ;
-    urnp:examples _:nc5fd07d2008e48268d06d8504e740453b2 ;
+    urnp:examples <urn:shapes:plot-description:climatic-condition:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/climatic-condition/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -135,7 +135,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:nc5fd07d2008e48268d06d8504e740453b2 ;
+    urnp:examples <urn:shapes:plot-description:climatic-condition:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/climatic-condition/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -166,7 +166,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:nc5fd07d2008e48268d06d8504e740453b2 ;
+    urnp:examples <urn:shapes:plot-description:climatic-condition:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/climatic-condition/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -195,7 +195,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:nc5fd07d2008e48268d06d8504e740453b2 ;
+    urnp:examples <urn:shapes:plot-description:climatic-condition:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/climatic-condition/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -225,11 +225,11 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                 sosa:hasResult ?this .
         }"""
         ] ;
-    urnp:examples _:nc5fd07d2008e48268d06d8504e740453b2 ;
+    urnp:examples <urn:shapes:plot-description:climatic-condition:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/climatic-condition/shapes.ttl"^^xsd:anyURI ;
 .
 
-_:nc5fd07d2008e48268d06d8504e740453b2
+<urn:shapes:plot-description:climatic-condition:examples>
     urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/climatic-condition/invalid.ttl"^^xsd:anyURI ;
     urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/climatic-condition/valid.ttl"^^xsd:anyURI ;
 .

--- a/shapes/plot-description-protocol-shapes/cover-class/shapes.ttl
+++ b/shapes/plot-description-protocol-shapes/cover-class/shapes.ttl
@@ -32,7 +32,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:naa88b8f8837f475b8202e63ee7573da7b2 ;
+    urnp:examples <urn:shapes:plot-description:cover-class:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-class/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -68,7 +68,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                 sosa:hasResult ?this .
         }"""
         ] ;
-    urnp:examples _:naa88b8f8837f475b8202e63ee7573da7b2 ;
+    urnp:examples <urn:shapes:plot-description:cover-class:examples> ;
     urnp:query """
         PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
         select ?values {
@@ -109,7 +109,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     """
         ] ;
     sh:targetClass tern:Observation ;
-    urnp:examples _:naa88b8f8837f475b8202e63ee7573da7b2 ;
+    urnp:examples <urn:shapes:plot-description:cover-class:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-class/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -139,7 +139,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:naa88b8f8837f475b8202e63ee7573da7b2 ;
+    urnp:examples <urn:shapes:plot-description:cover-class:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-class/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -170,7 +170,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:naa88b8f8837f475b8202e63ee7573da7b2 ;
+    urnp:examples <urn:shapes:plot-description:cover-class:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-class/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -199,7 +199,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:naa88b8f8837f475b8202e63ee7573da7b2 ;
+    urnp:examples <urn:shapes:plot-description:cover-class:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-class/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -229,11 +229,11 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                 sosa:hasResult ?this .
         }"""
         ] ;
-    urnp:examples _:naa88b8f8837f475b8202e63ee7573da7b2 ;
+    urnp:examples <urn:shapes:plot-description:cover-class:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-class/shapes.ttl"^^xsd:anyURI ;
 .
 
-_:naa88b8f8837f475b8202e63ee7573da7b2
+<urn:shapes:plot-description:cover-class:examples>
     urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-class/invalid.ttl"^^xsd:anyURI ;
     urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover-class/valid.ttl"^^xsd:anyURI ;
 .

--- a/shapes/plot-description-protocol-shapes/cover/shapes.ttl
+++ b/shapes/plot-description-protocol-shapes/cover/shapes.ttl
@@ -33,7 +33,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n27a07c6c3f51464588b3e09bf090ee8bb2 ;
+    urnp:examples <urn:shapes:plot-description:cover:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -65,7 +65,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     """
         ] ;
     sh:targetClass tern:Observation ;
-    urnp:examples _:n27a07c6c3f51464588b3e09bf090ee8bb2 ;
+    urnp:examples <urn:shapes:plot-description:cover:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -95,7 +95,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n27a07c6c3f51464588b3e09bf090ee8bb2 ;
+    urnp:examples <urn:shapes:plot-description:cover:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -123,7 +123,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                 sosa:hasResult ?this .
         }"""
         ] ;
-    urnp:examples _:n27a07c6c3f51464588b3e09bf090ee8bb2 ;
+    urnp:examples <urn:shapes:plot-description:cover:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -154,7 +154,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n27a07c6c3f51464588b3e09bf090ee8bb2 ;
+    urnp:examples <urn:shapes:plot-description:cover:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -184,7 +184,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                 sosa:hasResult ?this .
         }"""
         ] ;
-    urnp:examples _:n27a07c6c3f51464588b3e09bf090ee8bb2 ;
+    urnp:examples <urn:shapes:plot-description:cover:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -213,11 +213,11 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n27a07c6c3f51464588b3e09bf090ee8bb2 ;
+    urnp:examples <urn:shapes:plot-description:cover:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover/shapes.ttl"^^xsd:anyURI ;
 .
 
-_:n27a07c6c3f51464588b3e09bf090ee8bb2
+<urn:shapes:plot-description:cover:examples>
     urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover/invalid.ttl"^^xsd:anyURI ;
     urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/cover/valid.ttl"^^xsd:anyURI ;
 .

--- a/shapes/plot-description-protocol-shapes/disturbance-type/shapes.ttl
+++ b/shapes/plot-description-protocol-shapes/disturbance-type/shapes.ttl
@@ -32,7 +32,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n40acc97cac5642bb8a26fa247bc06a1ab2 ;
+    urnp:examples <urn:shapes:plot-description:disturbance-type:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/disturbance-type/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -74,7 +74,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                 sosa:hasResult ?this .
         }"""
         ] ;
-    urnp:examples _:n40acc97cac5642bb8a26fa247bc06a1ab2 ;
+    urnp:examples <urn:shapes:plot-description:disturbance-type:examples> ;
     urnp:query """
         PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
         select ?values {
@@ -115,7 +115,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     """
         ] ;
     sh:targetClass tern:Observation ;
-    urnp:examples _:n40acc97cac5642bb8a26fa247bc06a1ab2 ;
+    urnp:examples <urn:shapes:plot-description:disturbance-type:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/disturbance-type/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -145,7 +145,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n40acc97cac5642bb8a26fa247bc06a1ab2 ;
+    urnp:examples <urn:shapes:plot-description:disturbance-type:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/disturbance-type/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -176,7 +176,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n40acc97cac5642bb8a26fa247bc06a1ab2 ;
+    urnp:examples <urn:shapes:plot-description:disturbance-type:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/disturbance-type/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -205,7 +205,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n40acc97cac5642bb8a26fa247bc06a1ab2 ;
+    urnp:examples <urn:shapes:plot-description:disturbance-type:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/disturbance-type/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -235,11 +235,11 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                 sosa:hasResult ?this .
         }"""
         ] ;
-    urnp:examples _:n40acc97cac5642bb8a26fa247bc06a1ab2 ;
+    urnp:examples <urn:shapes:plot-description:disturbance-type:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/disturbance-type/shapes.ttl"^^xsd:anyURI ;
 .
 
-_:n40acc97cac5642bb8a26fa247bc06a1ab2
+<urn:shapes:plot-description:disturbance-type:examples>
     urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/disturbance-type/invalid.ttl"^^xsd:anyURI ;
     urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/disturbance-type/valid.ttl"^^xsd:anyURI ;
 .

--- a/shapes/plot-description-protocol-shapes/dominant-species/shapes.ttl
+++ b/shapes/plot-description-protocol-shapes/dominant-species/shapes.ttl
@@ -31,7 +31,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                 sosa:hasResult ?this .
         }"""
         ] ;
-    urnp:examples _:n8fcee7e348b445139618deb11a9ab077b2 ;
+    urnp:examples <urn:shapes:plot-description:dominant-species:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/dominant-species/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -60,7 +60,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n8fcee7e348b445139618deb11a9ab077b2 ;
+    urnp:examples <urn:shapes:plot-description:dominant-species:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/dominant-species/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -92,7 +92,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     """
         ] ;
     sh:targetClass tern:Observation ;
-    urnp:examples _:n8fcee7e348b445139618deb11a9ab077b2 ;
+    urnp:examples <urn:shapes:plot-description:dominant-species:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/dominant-species/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -122,7 +122,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n8fcee7e348b445139618deb11a9ab077b2 ;
+    urnp:examples <urn:shapes:plot-description:dominant-species:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/dominant-species/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -153,7 +153,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n8fcee7e348b445139618deb11a9ab077b2 ;
+    urnp:examples <urn:shapes:plot-description:dominant-species:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/dominant-species/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -182,11 +182,11 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n8fcee7e348b445139618deb11a9ab077b2 ;
+    urnp:examples <urn:shapes:plot-description:dominant-species:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/dominant-species/shapes.ttl"^^xsd:anyURI ;
 .
 
-_:n8fcee7e348b445139618deb11a9ab077b2
+<urn:shapes:plot-description:dominant-species:examples>
     urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/dominant-species/invalid.ttl"^^xsd:anyURI ;
     urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/dominant-species/valid.ttl"^^xsd:anyURI ;
 .

--- a/shapes/plot-description-protocol-shapes/fire-history/shapes.ttl
+++ b/shapes/plot-description-protocol-shapes/fire-history/shapes.ttl
@@ -32,7 +32,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n949dece8a8ad4da48d26de51962d35f7b2 ;
+    urnp:examples <urn:shapes:plot-description:fire-history:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/fire-history/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -65,7 +65,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                 sosa:hasResult ?this .
         }"""
         ] ;
-    urnp:examples _:n949dece8a8ad4da48d26de51962d35f7b2 ;
+    urnp:examples <urn:shapes:plot-description:fire-history:examples> ;
     urnp:query """
         PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
         select ?values {
@@ -106,7 +106,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     """
         ] ;
     sh:targetClass tern:Observation ;
-    urnp:examples _:n949dece8a8ad4da48d26de51962d35f7b2 ;
+    urnp:examples <urn:shapes:plot-description:fire-history:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/fire-history/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -136,7 +136,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n949dece8a8ad4da48d26de51962d35f7b2 ;
+    urnp:examples <urn:shapes:plot-description:fire-history:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/fire-history/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -167,7 +167,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n949dece8a8ad4da48d26de51962d35f7b2 ;
+    urnp:examples <urn:shapes:plot-description:fire-history:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/fire-history/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -196,7 +196,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n949dece8a8ad4da48d26de51962d35f7b2 ;
+    urnp:examples <urn:shapes:plot-description:fire-history:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/fire-history/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -226,11 +226,11 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                 sosa:hasResult ?this .
         }"""
         ] ;
-    urnp:examples _:n949dece8a8ad4da48d26de51962d35f7b2 ;
+    urnp:examples <urn:shapes:plot-description:fire-history:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/fire-history/shapes.ttl"^^xsd:anyURI ;
 .
 
-_:n949dece8a8ad4da48d26de51962d35f7b2
+<urn:shapes:plot-description:fire-history:examples>
     urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/fire-history/invalid.ttl"^^xsd:anyURI ;
     urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/fire-history/valid.ttl"^^xsd:anyURI ;
 .

--- a/shapes/plot-description-protocol-shapes/growth-form/shapes.ttl
+++ b/shapes/plot-description-protocol-shapes/growth-form/shapes.ttl
@@ -32,7 +32,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n9ef5efd711584fe5830be9d9091708b3b2 ;
+    urnp:examples <urn:shapes:plot-description:growth-form:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-form/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -89,7 +89,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                 sosa:hasResult ?this .
         }"""
         ] ;
-    urnp:examples _:n9ef5efd711584fe5830be9d9091708b3b2 ;
+    urnp:examples <urn:shapes:plot-description:growth-form:examples> ;
     urnp:query """
         PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
         select ?values {
@@ -130,7 +130,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     """
         ] ;
     sh:targetClass tern:Observation ;
-    urnp:examples _:n9ef5efd711584fe5830be9d9091708b3b2 ;
+    urnp:examples <urn:shapes:plot-description:growth-form:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-form/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -160,7 +160,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n9ef5efd711584fe5830be9d9091708b3b2 ;
+    urnp:examples <urn:shapes:plot-description:growth-form:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-form/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -191,7 +191,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n9ef5efd711584fe5830be9d9091708b3b2 ;
+    urnp:examples <urn:shapes:plot-description:growth-form:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-form/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -220,7 +220,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n9ef5efd711584fe5830be9d9091708b3b2 ;
+    urnp:examples <urn:shapes:plot-description:growth-form:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-form/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -250,11 +250,11 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                 sosa:hasResult ?this .
         }"""
         ] ;
-    urnp:examples _:n9ef5efd711584fe5830be9d9091708b3b2 ;
+    urnp:examples <urn:shapes:plot-description:growth-form:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-form/shapes.ttl"^^xsd:anyURI ;
 .
 
-_:n9ef5efd711584fe5830be9d9091708b3b2
+<urn:shapes:plot-description:growth-form:examples>
     urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-form/invalid.ttl"^^xsd:anyURI ;
     urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-form/valid.ttl"^^xsd:anyURI ;
 .

--- a/shapes/plot-description-protocol-shapes/growth-stage/shapes.ttl
+++ b/shapes/plot-description-protocol-shapes/growth-stage/shapes.ttl
@@ -32,7 +32,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n20d683d88d7b4c3f8038bbf2d95c74c6b2 ;
+    urnp:examples <urn:shapes:plot-description:growth-stage:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-stage/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -67,7 +67,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                 sosa:hasResult ?this .
         }"""
         ] ;
-    urnp:examples _:n20d683d88d7b4c3f8038bbf2d95c74c6b2 ;
+    urnp:examples <urn:shapes:plot-description:growth-stage:examples> ;
     urnp:query """
         PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
         select ?values {
@@ -108,7 +108,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     """
         ] ;
     sh:targetClass tern:Observation ;
-    urnp:examples _:n20d683d88d7b4c3f8038bbf2d95c74c6b2 ;
+    urnp:examples <urn:shapes:plot-description:growth-stage:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-stage/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -138,7 +138,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n20d683d88d7b4c3f8038bbf2d95c74c6b2 ;
+    urnp:examples <urn:shapes:plot-description:growth-stage:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-stage/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -169,7 +169,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n20d683d88d7b4c3f8038bbf2d95c74c6b2 ;
+    urnp:examples <urn:shapes:plot-description:growth-stage:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-stage/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -198,7 +198,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n20d683d88d7b4c3f8038bbf2d95c74c6b2 ;
+    urnp:examples <urn:shapes:plot-description:growth-stage:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-stage/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -228,11 +228,11 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                 sosa:hasResult ?this .
         }"""
         ] ;
-    urnp:examples _:n20d683d88d7b4c3f8038bbf2d95c74c6b2 ;
+    urnp:examples <urn:shapes:plot-description:growth-stage:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-stage/shapes.ttl"^^xsd:anyURI ;
 .
 
-_:n20d683d88d7b4c3f8038bbf2d95c74c6b2
+<urn:shapes:plot-description:growth-stage:examples>
     urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-stage/invalid.ttl"^^xsd:anyURI ;
     urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/growth-stage/valid.ttl"^^xsd:anyURI ;
 .

--- a/shapes/plot-description-protocol-shapes/height-class/shapes.ttl
+++ b/shapes/plot-description-protocol-shapes/height-class/shapes.ttl
@@ -32,7 +32,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n9222b9e121ae469a9a53d06120bace60b2 ;
+    urnp:examples <urn:shapes:plot-description:height-class:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/height-class/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -73,7 +73,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                 sosa:hasResult ?this .
         }"""
         ] ;
-    urnp:examples _:n9222b9e121ae469a9a53d06120bace60b2 ;
+    urnp:examples <urn:shapes:plot-description:height-class:examples> ;
     urnp:query """
         PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
         select ?values {
@@ -114,7 +114,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     """
         ] ;
     sh:targetClass tern:Observation ;
-    urnp:examples _:n9222b9e121ae469a9a53d06120bace60b2 ;
+    urnp:examples <urn:shapes:plot-description:height-class:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/height-class/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -144,7 +144,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n9222b9e121ae469a9a53d06120bace60b2 ;
+    urnp:examples <urn:shapes:plot-description:height-class:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/height-class/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -175,7 +175,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n9222b9e121ae469a9a53d06120bace60b2 ;
+    urnp:examples <urn:shapes:plot-description:height-class:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/height-class/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -204,7 +204,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n9222b9e121ae469a9a53d06120bace60b2 ;
+    urnp:examples <urn:shapes:plot-description:height-class:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/height-class/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -234,11 +234,11 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                 sosa:hasResult ?this .
         }"""
         ] ;
-    urnp:examples _:n9222b9e121ae469a9a53d06120bace60b2 ;
+    urnp:examples <urn:shapes:plot-description:height-class:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/height-class/shapes.ttl"^^xsd:anyURI ;
 .
 
-_:n9222b9e121ae469a9a53d06120bace60b2
+<urn:shapes:plot-description:height-class:examples>
     urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/height-class/invalid.ttl"^^xsd:anyURI ;
     urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/height-class/valid.ttl"^^xsd:anyURI ;
 .

--- a/shapes/plot-description-protocol-shapes/homogeneity-measure/shapes.ttl
+++ b/shapes/plot-description-protocol-shapes/homogeneity-measure/shapes.ttl
@@ -33,7 +33,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:nf160de66cd124a8597f6fc5c7c126f2eb2 ;
+    urnp:examples <urn:shapes:plot-description:homogeneity-measure:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/homogeneity-measure/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -65,7 +65,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     """
         ] ;
     sh:targetClass tern:Observation ;
-    urnp:examples _:nf160de66cd124a8597f6fc5c7c126f2eb2 ;
+    urnp:examples <urn:shapes:plot-description:homogeneity-measure:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/homogeneity-measure/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -95,7 +95,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:nf160de66cd124a8597f6fc5c7c126f2eb2 ;
+    urnp:examples <urn:shapes:plot-description:homogeneity-measure:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/homogeneity-measure/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -123,7 +123,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                 sosa:hasResult ?this .
         }"""
         ] ;
-    urnp:examples _:nf160de66cd124a8597f6fc5c7c126f2eb2 ;
+    urnp:examples <urn:shapes:plot-description:homogeneity-measure:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/homogeneity-measure/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -154,7 +154,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:nf160de66cd124a8597f6fc5c7c126f2eb2 ;
+    urnp:examples <urn:shapes:plot-description:homogeneity-measure:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/homogeneity-measure/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -183,7 +183,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                 sosa:hasResult ?this .
         }"""
         ] ;
-    urnp:examples _:nf160de66cd124a8597f6fc5c7c126f2eb2 ;
+    urnp:examples <urn:shapes:plot-description:homogeneity-measure:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/homogeneity-measure/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -212,11 +212,11 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:nf160de66cd124a8597f6fc5c7c126f2eb2 ;
+    urnp:examples <urn:shapes:plot-description:homogeneity-measure:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/homogeneity-measure/shapes.ttl"^^xsd:anyURI ;
 .
 
-_:nf160de66cd124a8597f6fc5c7c126f2eb2
+<urn:shapes:plot-description:homogeneity-measure:examples>
     urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/homogeneity-measure/invalid.ttl"^^xsd:anyURI ;
     urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/homogeneity-measure/valid.ttl"^^xsd:anyURI ;
 .

--- a/shapes/plot-description-protocol-shapes/landform-element/shapes.ttl
+++ b/shapes/plot-description-protocol-shapes/landform-element/shapes.ttl
@@ -32,7 +32,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:ned73c30ee8f24534a394e3cf9f4dcf8ab2 ;
+    urnp:examples <urn:shapes:plot-description:landform-element:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-element/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -142,7 +142,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                 sosa:hasResult ?this .
         }"""
         ] ;
-    urnp:examples _:ned73c30ee8f24534a394e3cf9f4dcf8ab2 ;
+    urnp:examples <urn:shapes:plot-description:landform-element:examples> ;
     urnp:query """
         PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
         select ?values {
@@ -183,7 +183,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     """
         ] ;
     sh:targetClass tern:Observation ;
-    urnp:examples _:ned73c30ee8f24534a394e3cf9f4dcf8ab2 ;
+    urnp:examples <urn:shapes:plot-description:landform-element:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-element/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -213,7 +213,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:ned73c30ee8f24534a394e3cf9f4dcf8ab2 ;
+    urnp:examples <urn:shapes:plot-description:landform-element:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-element/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -244,7 +244,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:ned73c30ee8f24534a394e3cf9f4dcf8ab2 ;
+    urnp:examples <urn:shapes:plot-description:landform-element:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-element/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -273,7 +273,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:ned73c30ee8f24534a394e3cf9f4dcf8ab2 ;
+    urnp:examples <urn:shapes:plot-description:landform-element:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-element/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -303,11 +303,11 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                 sosa:hasResult ?this .
         }"""
         ] ;
-    urnp:examples _:ned73c30ee8f24534a394e3cf9f4dcf8ab2 ;
+    urnp:examples <urn:shapes:plot-description:landform-element:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-element/shapes.ttl"^^xsd:anyURI ;
 .
 
-_:ned73c30ee8f24534a394e3cf9f4dcf8ab2
+<urn:shapes:plot-description:landform-element:examples>
     urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-element/invalid.ttl"^^xsd:anyURI ;
     urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-element/valid.ttl"^^xsd:anyURI ;
 .

--- a/shapes/plot-description-protocol-shapes/landform-pattern/shapes.ttl
+++ b/shapes/plot-description-protocol-shapes/landform-pattern/shapes.ttl
@@ -32,7 +32,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n9ad7e2f82dfd4dbbb6e6eb255cfa8952b2 ;
+    urnp:examples <urn:shapes:plot-description:landform-pattern:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-pattern/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -103,7 +103,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                 sosa:hasResult ?this .
         }"""
         ] ;
-    urnp:examples _:n9ad7e2f82dfd4dbbb6e6eb255cfa8952b2 ;
+    urnp:examples <urn:shapes:plot-description:landform-pattern:examples> ;
     urnp:query """
         PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
         select ?values {
@@ -144,7 +144,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     """
         ] ;
     sh:targetClass tern:Observation ;
-    urnp:examples _:n9ad7e2f82dfd4dbbb6e6eb255cfa8952b2 ;
+    urnp:examples <urn:shapes:plot-description:landform-pattern:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-pattern/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -174,7 +174,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n9ad7e2f82dfd4dbbb6e6eb255cfa8952b2 ;
+    urnp:examples <urn:shapes:plot-description:landform-pattern:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-pattern/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -205,7 +205,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n9ad7e2f82dfd4dbbb6e6eb255cfa8952b2 ;
+    urnp:examples <urn:shapes:plot-description:landform-pattern:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-pattern/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -234,7 +234,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n9ad7e2f82dfd4dbbb6e6eb255cfa8952b2 ;
+    urnp:examples <urn:shapes:plot-description:landform-pattern:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-pattern/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -264,11 +264,11 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                 sosa:hasResult ?this .
         }"""
         ] ;
-    urnp:examples _:n9ad7e2f82dfd4dbbb6e6eb255cfa8952b2 ;
+    urnp:examples <urn:shapes:plot-description:landform-pattern:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-pattern/shapes.ttl"^^xsd:anyURI ;
 .
 
-_:n9ad7e2f82dfd4dbbb6e6eb255cfa8952b2
+<urn:shapes:plot-description:landform-pattern:examples>
     urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-pattern/invalid.ttl"^^xsd:anyURI ;
     urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/landform-pattern/valid.ttl"^^xsd:anyURI ;
 .

--- a/shapes/plot-description-protocol-shapes/rock-outcrop-lithology/shapes.ttl
+++ b/shapes/plot-description-protocol-shapes/rock-outcrop-lithology/shapes.ttl
@@ -32,7 +32,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:nec501f5c5a1b48a4938e6e436a406c47b2 ;
+    urnp:examples <urn:shapes:plot-description:rock-outcrop-lithology:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/rock-outcrop-lithology/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -152,7 +152,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                 sosa:hasResult ?this .
         }"""
         ] ;
-    urnp:examples _:nec501f5c5a1b48a4938e6e436a406c47b2 ;
+    urnp:examples <urn:shapes:plot-description:rock-outcrop-lithology:examples> ;
     urnp:query """
         PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
         select ?values {
@@ -193,7 +193,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     """
         ] ;
     sh:targetClass tern:Observation ;
-    urnp:examples _:nec501f5c5a1b48a4938e6e436a406c47b2 ;
+    urnp:examples <urn:shapes:plot-description:rock-outcrop-lithology:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/rock-outcrop-lithology/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -223,7 +223,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:nec501f5c5a1b48a4938e6e436a406c47b2 ;
+    urnp:examples <urn:shapes:plot-description:rock-outcrop-lithology:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/rock-outcrop-lithology/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -254,7 +254,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:nec501f5c5a1b48a4938e6e436a406c47b2 ;
+    urnp:examples <urn:shapes:plot-description:rock-outcrop-lithology:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/rock-outcrop-lithology/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -283,7 +283,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:nec501f5c5a1b48a4938e6e436a406c47b2 ;
+    urnp:examples <urn:shapes:plot-description:rock-outcrop-lithology:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/rock-outcrop-lithology/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -313,11 +313,11 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                 sosa:hasResult ?this .
         }"""
         ] ;
-    urnp:examples _:nec501f5c5a1b48a4938e6e436a406c47b2 ;
+    urnp:examples <urn:shapes:plot-description:rock-outcrop-lithology:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/rock-outcrop-lithology/shapes.ttl"^^xsd:anyURI ;
 .
 
-_:nec501f5c5a1b48a4938e6e436a406c47b2
+<urn:shapes:plot-description:rock-outcrop-lithology:examples>
     urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/rock-outcrop-lithology/invalid.ttl"^^xsd:anyURI ;
     urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/rock-outcrop-lithology/valid.ttl"^^xsd:anyURI ;
 .

--- a/shapes/plot-description-protocol-shapes/second-dominant-species/shapes.ttl
+++ b/shapes/plot-description-protocol-shapes/second-dominant-species/shapes.ttl
@@ -31,7 +31,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                 sosa:hasResult ?this .
         }"""
         ] ;
-    urnp:examples _:n302cc27eed834bdcb2e6f3ebf8ff26f3b2 ;
+    urnp:examples <urn:shapes:plot-description:second-dominant-species:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/second-dominant-species/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -60,7 +60,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n302cc27eed834bdcb2e6f3ebf8ff26f3b2 ;
+    urnp:examples <urn:shapes:plot-description:second-dominant-species:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/second-dominant-species/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -92,7 +92,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     """
         ] ;
     sh:targetClass tern:Observation ;
-    urnp:examples _:n302cc27eed834bdcb2e6f3ebf8ff26f3b2 ;
+    urnp:examples <urn:shapes:plot-description:second-dominant-species:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/second-dominant-species/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -122,7 +122,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n302cc27eed834bdcb2e6f3ebf8ff26f3b2 ;
+    urnp:examples <urn:shapes:plot-description:second-dominant-species:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/second-dominant-species/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -153,7 +153,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n302cc27eed834bdcb2e6f3ebf8ff26f3b2 ;
+    urnp:examples <urn:shapes:plot-description:second-dominant-species:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/second-dominant-species/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -182,11 +182,11 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n302cc27eed834bdcb2e6f3ebf8ff26f3b2 ;
+    urnp:examples <urn:shapes:plot-description:second-dominant-species:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/second-dominant-species/shapes.ttl"^^xsd:anyURI ;
 .
 
-_:n302cc27eed834bdcb2e6f3ebf8ff26f3b2
+<urn:shapes:plot-description:second-dominant-species:examples>
     urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/second-dominant-species/invalid.ttl"^^xsd:anyURI ;
     urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/second-dominant-species/valid.ttl"^^xsd:anyURI ;
 .

--- a/shapes/plot-description-protocol-shapes/slope-class/shapes.ttl
+++ b/shapes/plot-description-protocol-shapes/slope-class/shapes.ttl
@@ -32,7 +32,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:nc1c550a610e04ad6b78d0f7dc533809cb2 ;
+    urnp:examples <urn:shapes:plot-description:slope-class:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope-class/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -70,7 +70,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                 sosa:hasResult ?this .
         }"""
         ] ;
-    urnp:examples _:nc1c550a610e04ad6b78d0f7dc533809cb2 ;
+    urnp:examples <urn:shapes:plot-description:slope-class:examples> ;
     urnp:query """
         PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
         select ?values {
@@ -111,7 +111,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     """
         ] ;
     sh:targetClass tern:Observation ;
-    urnp:examples _:nc1c550a610e04ad6b78d0f7dc533809cb2 ;
+    urnp:examples <urn:shapes:plot-description:slope-class:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope-class/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -141,7 +141,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:nc1c550a610e04ad6b78d0f7dc533809cb2 ;
+    urnp:examples <urn:shapes:plot-description:slope-class:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope-class/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -172,7 +172,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:nc1c550a610e04ad6b78d0f7dc533809cb2 ;
+    urnp:examples <urn:shapes:plot-description:slope-class:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope-class/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -201,7 +201,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:nc1c550a610e04ad6b78d0f7dc533809cb2 ;
+    urnp:examples <urn:shapes:plot-description:slope-class:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope-class/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -231,11 +231,11 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                 sosa:hasResult ?this .
         }"""
         ] ;
-    urnp:examples _:nc1c550a610e04ad6b78d0f7dc533809cb2 ;
+    urnp:examples <urn:shapes:plot-description:slope-class:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope-class/shapes.ttl"^^xsd:anyURI ;
 .
 
-_:nc1c550a610e04ad6b78d0f7dc533809cb2
+<urn:shapes:plot-description:slope-class:examples>
     urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope-class/invalid.ttl"^^xsd:anyURI ;
     urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope-class/valid.ttl"^^xsd:anyURI ;
 .

--- a/shapes/plot-description-protocol-shapes/slope/shapes.ttl
+++ b/shapes/plot-description-protocol-shapes/slope/shapes.ttl
@@ -33,7 +33,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:nf0d9d51a985f459ca9e089f05d0a9504b2 ;
+    urnp:examples <urn:shapes:plot-description:slope:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -65,7 +65,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     """
         ] ;
     sh:targetClass tern:Observation ;
-    urnp:examples _:nf0d9d51a985f459ca9e089f05d0a9504b2 ;
+    urnp:examples <urn:shapes:plot-description:slope:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -95,7 +95,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:nf0d9d51a985f459ca9e089f05d0a9504b2 ;
+    urnp:examples <urn:shapes:plot-description:slope:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -123,7 +123,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                 sosa:hasResult ?this .
         }"""
         ] ;
-    urnp:examples _:nf0d9d51a985f459ca9e089f05d0a9504b2 ;
+    urnp:examples <urn:shapes:plot-description:slope:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -154,7 +154,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:nf0d9d51a985f459ca9e089f05d0a9504b2 ;
+    urnp:examples <urn:shapes:plot-description:slope:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -184,7 +184,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                 sosa:hasResult ?this .
         }"""
         ] ;
-    urnp:examples _:nf0d9d51a985f459ca9e089f05d0a9504b2 ;
+    urnp:examples <urn:shapes:plot-description:slope:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -213,11 +213,11 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:nf0d9d51a985f459ca9e089f05d0a9504b2 ;
+    urnp:examples <urn:shapes:plot-description:slope:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope/shapes.ttl"^^xsd:anyURI ;
 .
 
-_:nf0d9d51a985f459ca9e089f05d0a9504b2
+<urn:shapes:plot-description:slope:examples>
     urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope/invalid.ttl"^^xsd:anyURI ;
     urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/slope/valid.ttl"^^xsd:anyURI ;
 .

--- a/shapes/plot-description-protocol-shapes/structural-formation/shapes.ttl
+++ b/shapes/plot-description-protocol-shapes/structural-formation/shapes.ttl
@@ -32,7 +32,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n0f1e8c03b82f4d1fa76c0290c6353676b2 ;
+    urnp:examples <urn:shapes:plot-description:structural-formation:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/structural-formation/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -167,7 +167,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                 sosa:hasResult ?this .
         }"""
         ] ;
-    urnp:examples _:n0f1e8c03b82f4d1fa76c0290c6353676b2 ;
+    urnp:examples <urn:shapes:plot-description:structural-formation:examples> ;
     urnp:query """
         PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
         select ?values {
@@ -208,7 +208,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     """
         ] ;
     sh:targetClass tern:Observation ;
-    urnp:examples _:n0f1e8c03b82f4d1fa76c0290c6353676b2 ;
+    urnp:examples <urn:shapes:plot-description:structural-formation:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/structural-formation/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -238,7 +238,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n0f1e8c03b82f4d1fa76c0290c6353676b2 ;
+    urnp:examples <urn:shapes:plot-description:structural-formation:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/structural-formation/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -269,7 +269,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n0f1e8c03b82f4d1fa76c0290c6353676b2 ;
+    urnp:examples <urn:shapes:plot-description:structural-formation:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/structural-formation/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -298,7 +298,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n0f1e8c03b82f4d1fa76c0290c6353676b2 ;
+    urnp:examples <urn:shapes:plot-description:structural-formation:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/structural-formation/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -328,11 +328,11 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                 sosa:hasResult ?this .
         }"""
         ] ;
-    urnp:examples _:n0f1e8c03b82f4d1fa76c0290c6353676b2 ;
+    urnp:examples <urn:shapes:plot-description:structural-formation:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/structural-formation/shapes.ttl"^^xsd:anyURI ;
 .
 
-_:n0f1e8c03b82f4d1fa76c0290c6353676b2
+<urn:shapes:plot-description:structural-formation:examples>
     urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/structural-formation/invalid.ttl"^^xsd:anyURI ;
     urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/structural-formation/valid.ttl"^^xsd:anyURI ;
 .

--- a/shapes/plot-description-protocol-shapes/surface-strew-lithology/shapes.ttl
+++ b/shapes/plot-description-protocol-shapes/surface-strew-lithology/shapes.ttl
@@ -32,7 +32,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n61fec6f1944a4315b7c0aef6a10719c5b2 ;
+    urnp:examples <urn:shapes:plot-description:surface-strew-lithology:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-lithology/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -152,7 +152,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                 sosa:hasResult ?this .
         }"""
         ] ;
-    urnp:examples _:n61fec6f1944a4315b7c0aef6a10719c5b2 ;
+    urnp:examples <urn:shapes:plot-description:surface-strew-lithology:examples> ;
     urnp:query """
         PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
         select ?values {
@@ -193,7 +193,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     """
         ] ;
     sh:targetClass tern:Observation ;
-    urnp:examples _:n61fec6f1944a4315b7c0aef6a10719c5b2 ;
+    urnp:examples <urn:shapes:plot-description:surface-strew-lithology:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-lithology/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -223,7 +223,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n61fec6f1944a4315b7c0aef6a10719c5b2 ;
+    urnp:examples <urn:shapes:plot-description:surface-strew-lithology:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-lithology/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -254,7 +254,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n61fec6f1944a4315b7c0aef6a10719c5b2 ;
+    urnp:examples <urn:shapes:plot-description:surface-strew-lithology:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-lithology/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -283,7 +283,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:n61fec6f1944a4315b7c0aef6a10719c5b2 ;
+    urnp:examples <urn:shapes:plot-description:surface-strew-lithology:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-lithology/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -313,11 +313,11 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                 sosa:hasResult ?this .
         }"""
         ] ;
-    urnp:examples _:n61fec6f1944a4315b7c0aef6a10719c5b2 ;
+    urnp:examples <urn:shapes:plot-description:surface-strew-lithology:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-lithology/shapes.ttl"^^xsd:anyURI ;
 .
 
-_:n61fec6f1944a4315b7c0aef6a10719c5b2
+<urn:shapes:plot-description:surface-strew-lithology:examples>
     urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-lithology/invalid.ttl"^^xsd:anyURI ;
     urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-lithology/valid.ttl"^^xsd:anyURI ;
 .

--- a/shapes/plot-description-protocol-shapes/surface-strew-size/shapes.ttl
+++ b/shapes/plot-description-protocol-shapes/surface-strew-size/shapes.ttl
@@ -32,7 +32,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:na50f8a3d72834dedacd3cde8caee5164b2 ;
+    urnp:examples <urn:shapes:plot-description:surface-strew-size:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-size/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -67,7 +67,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                 sosa:hasResult ?this .
         }"""
         ] ;
-    urnp:examples _:na50f8a3d72834dedacd3cde8caee5164b2 ;
+    urnp:examples <urn:shapes:plot-description:surface-strew-size:examples> ;
     urnp:query """
         PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
         select ?values {
@@ -108,7 +108,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     """
         ] ;
     sh:targetClass tern:Observation ;
-    urnp:examples _:na50f8a3d72834dedacd3cde8caee5164b2 ;
+    urnp:examples <urn:shapes:plot-description:surface-strew-size:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-size/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -138,7 +138,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:na50f8a3d72834dedacd3cde8caee5164b2 ;
+    urnp:examples <urn:shapes:plot-description:surface-strew-size:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-size/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -169,7 +169,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:na50f8a3d72834dedacd3cde8caee5164b2 ;
+    urnp:examples <urn:shapes:plot-description:surface-strew-size:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-size/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -198,7 +198,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:na50f8a3d72834dedacd3cde8caee5164b2 ;
+    urnp:examples <urn:shapes:plot-description:surface-strew-size:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-size/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -228,11 +228,11 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                 sosa:hasResult ?this .
         }"""
         ] ;
-    urnp:examples _:na50f8a3d72834dedacd3cde8caee5164b2 ;
+    urnp:examples <urn:shapes:plot-description:surface-strew-size:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-size/shapes.ttl"^^xsd:anyURI ;
 .
 
-_:na50f8a3d72834dedacd3cde8caee5164b2
+<urn:shapes:plot-description:surface-strew-size:examples>
     urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-size/invalid.ttl"^^xsd:anyURI ;
     urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/surface-strew-size/valid.ttl"^^xsd:anyURI ;
 .

--- a/shapes/plot-description-protocol-shapes/third-dominant-species/shapes.ttl
+++ b/shapes/plot-description-protocol-shapes/third-dominant-species/shapes.ttl
@@ -31,7 +31,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                 sosa:hasResult ?this .
         }"""
         ] ;
-    urnp:examples _:nec45118ad0ad4d7bb6aa846b42f5e1ebb2 ;
+    urnp:examples <urn:shapes:plot-description:third-dominant-species:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/third-dominant-species/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -60,7 +60,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:nec45118ad0ad4d7bb6aa846b42f5e1ebb2 ;
+    urnp:examples <urn:shapes:plot-description:third-dominant-species:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/third-dominant-species/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -92,7 +92,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     """
         ] ;
     sh:targetClass tern:Observation ;
-    urnp:examples _:nec45118ad0ad4d7bb6aa846b42f5e1ebb2 ;
+    urnp:examples <urn:shapes:plot-description:third-dominant-species:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/third-dominant-species/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -122,7 +122,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:nec45118ad0ad4d7bb6aa846b42f5e1ebb2 ;
+    urnp:examples <urn:shapes:plot-description:third-dominant-species:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/third-dominant-species/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -153,7 +153,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:nec45118ad0ad4d7bb6aa846b42f5e1ebb2 ;
+    urnp:examples <urn:shapes:plot-description:third-dominant-species:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/third-dominant-species/shapes.ttl"^^xsd:anyURI ;
 .
 
@@ -182,11 +182,11 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     }
     """
         ] ;
-    urnp:examples _:nec45118ad0ad4d7bb6aa846b42f5e1ebb2 ;
+    urnp:examples <urn:shapes:plot-description:third-dominant-species:examples> ;
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/third-dominant-species/shapes.ttl"^^xsd:anyURI ;
 .
 
-_:nec45118ad0ad4d7bb6aa846b42f5e1ebb2
+<urn:shapes:plot-description:third-dominant-species:examples>
     urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/third-dominant-species/invalid.ttl"^^xsd:anyURI ;
     urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/third-dominant-species/valid.ttl"^^xsd:anyURI ;
 .


### PR DESCRIPTION
Previously example files nodes are blank nodes and those IDs are changed during normalization. 

Now each example file node has meaningful URI.