### PR TITLE
Added workflow to generate SHACL shapes at once

### DIFF
--- a/src/update_shapes/functions.py
+++ b/src/update_shapes/functions.py
@@ -1,0 +1,46 @@
+import requests
+from requests.exceptions import HTTPError
+
+class SPARQLQueryError(Exception):
+    pass
+
+
+def sparql_query(url: str, query: str):
+    headers = {
+        "Content-type": "application/sparql-query",
+        "Accept": "application/sparql-results+json",
+    }
+    r = requests.post(url, headers=headers, data=query)
+    try:
+        r.raise_for_status()
+    except HTTPError as err:
+        raise SPARQLQueryError(
+            f"Failed fetching data from {url} SPARQL endpoint. Code: {r.status_code} Message: {r.text}."
+        ) from err
+    return r.json()
+
+
+def get_xsd_datatype(value_type):
+    if value_type == "tern:Text":
+        return "string"
+    elif value_type == "tern:Boolean":
+        return "boolean"
+    elif value_type == "tern:Date":
+        return "date"
+    elif value_type == "tern:DateTime":
+        return "dateTime"
+    elif value_type == "tern:Float":
+        return "float"
+    elif value_type == "tern:Integer":
+        return "integer"
+    
+
+def generate_op_shapes_folder(op_label):
+    op_shapes_folder_path = (
+        "-".join(op_label.split())
+        .replace("--", "-")
+        .replace("--", "-")
+        .replace("(", "")
+        .replace(")", "")
+    )
+    return op_shapes_folder_path

--- a/src/update_shapes/queries.py
+++ b/src/update_shapes/queries.py
@@ -1,0 +1,90 @@
+from functions import sparql_query
+from settings import dawe_endpoint, tern_endpoint
+
+import string
+
+def get_op_collection_members(properties_collection_uri):
+
+    q_get_op_collection_members = """
+    PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+    select ?properties where { 
+        values ?s {$properties_collection_uri}
+        ?s skos:member ?properties .
+    }
+    """
+
+    q_get_op_collection_members = string.Template(
+    q_get_op_collection_members
+    ).substitute(properties_collection_uri=f"<{properties_collection_uri}>")
+
+    op_collection_members = [
+        i["properties"]["value"]
+        for i in sparql_query(dawe_endpoint, q_get_op_collection_members)[
+            "results"
+        ]["bindings"]
+    ]
+
+    return op_collection_members
+
+def get_op_meta_info(property_uri, method_uri):
+    q_get_op_info = """
+    select ?featureType ?valueType {
+        values ?property_uri {$property_uri}
+        values ?method_uri {$method_uri}
+        ?s <urn:property:featureType> ?featureType ;
+        <urn:property:valueType> ?valueType ;
+        <urn:property:observableProperty> ?property_uri ;
+        <urn:property:protocolModule> ?method_uri .
+        }
+    """
+
+    q_get_op_info = string.Template(q_get_op_info).safe_substitute(
+        property_uri=f"<{property_uri}>",
+        method_uri=f"<{method_uri}>"
+    )
+
+    op_info_list = sparql_query(dawe_endpoint, q_get_op_info)["results"][
+        "bindings"
+    ]
+
+    op_feature_type = op_info_list[0]["featureType"]["value"]
+    op_value_type = op_info_list[0]["valueType"]["value"]
+
+    return op_feature_type, op_value_type
+
+def get_op_label(property_uri):
+    q_get_op_label = """
+    PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+    select ?label {
+    values ?property_uri {$property_uri}
+    ?property_uri skos:prefLabel ?label .
+    }
+    """
+
+    q_get_op_label = string.Template(q_get_op_label).substitute(
+        property_uri=f"<{property_uri}>"
+    )
+
+    op_label = sparql_query(dawe_endpoint, q_get_op_label)["results"][
+        "bindings"
+    ][0]["label"]["value"]
+
+    return op_label
+
+def get_feature_type_label(feature_type_uri):
+    q_get_feature_type_label = """
+    PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+    select ?label {
+        values ?s {$feature_type_uri}
+        ?s skos:prefLabel ?label .
+    }
+    """
+    q_get_feature_type_label = string.Template(
+        q_get_feature_type_label
+    ).substitute(feature_type_uri=f"<{feature_type_uri}>")
+
+    feature_type_label = sparql_query(
+        tern_endpoint, q_get_feature_type_label
+    )["results"]["bindings"][0]["label"]["value"].replace("-", " ")
+
+    return feature_type_label

--- a/src/update_shapes/settings.py
+++ b/src/update_shapes/settings.py
@@ -1,0 +1,10 @@
+from rdflib import Namespace
+
+URNC = Namespace("urn:class:")
+URNP = Namespace("urn:property:")
+REG = Namespace("http://purl.org/linked-data/registry#")
+TERN = Namespace("https://w3id.org/tern/ontologies/tern/")
+UNIT = Namespace("http://qudt.org/vocab/unit/")
+
+dawe_endpoint = "https://graphdb.tern.org.au/repositories/dawe_vocabs_core"
+tern_endpoint = "https://graphdb.tern.org.au/repositories/tern_vocabs_core"


### PR DESCRIPTION
EMSA surveys keep changing and SHACL shapes should be updated as well. This PR adds scripts to generate SHACL shapes for all EMSA modules by one command. 
This is a manually activated workflow, for version control purpose.