### PR TITLE
Updated the Categorical Values for fire-history in SHACL shapes for 3 protocols

### DIFF
--- a/shapes/plot-description/plot-description-enhanced-protocol-shapes/fire-history/invalid.ttl
+++ b/shapes/plot-description/plot-description-enhanced-protocol-shapes/fire-history/invalid.ttl
@@ -23,11 +23,11 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             a
                 tern:IRI ,
                 tern:Value ;
-            rdf:value <https://linked.data.gov.au/def/nrm/b537013e-17bb-5c0c-aa7b-279bcd0e52df> ;
+            rdf:value <https://linked.data.gov.au/def/nrm/be2897e6-c4ef-49af-973b-f902908939a9> ;
             sosa:isResultOf <urn:test:plot-description-enhanced-protocol-shapes:invalid:fire-history:feature-type> ;
             tern:vocabulary <https://linked.data.gov.au/def/nrm/6e9d2f51-ce64-4c67-8391-d14a8bf96b6b>
         ] ;
-    sosa:hasSimpleResult <https://linked.data.gov.au/def/nrm/b537013e-17bb-5c0c-aa7b-279bcd0e52df> ;
+    sosa:hasSimpleResult <https://linked.data.gov.au/def/nrm/be2897e6-c4ef-49af-973b-f902908939a9> ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/cf1aef8a-a782-4480-9c41-a7f6d170d7fc> ;
     sosa:phenomenonTime <https://example.com/observation/fire-history/b91c54f2-9354-43ee-8412-09974fd2c23c/phenomenonTime> ;
     sosa:resultTime "2022-09-27T05:38:47.117000+00:00"^^xsd:dateTime ;
@@ -73,7 +73,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             a
                 tern:IRI ,
                 tern:Value ;
-            rdf:value <https://linked.data.gov.au/def/nrm/b537013e-17bb-5c0c-aa7b-279bcd0e52df> ;
+            rdf:value <https://linked.data.gov.au/def/nrm/be2897e6-c4ef-49af-973b-f902908939a9> ;
             sosa:isResultOf <urn:test:plot-description-enhanced-protocol-shapes:invalid:fire-history:simple-result> ;
             tern:vocabulary <https://linked.data.gov.au/def/nrm/6e9d2f51-ce64-4c67-8391-d14a8bf96b6b>
         ] ;
@@ -98,11 +98,11 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             a
                 tern:IRI ,
                 tern:Value ;
-            rdf:value <https://linked.data.gov.au/def/nrm/b537013e-17bb-5c0c-aa7b-279bcd0e52df> ;
+            rdf:value <https://linked.data.gov.au/def/nrm/be2897e6-c4ef-49af-973b-f902908939a9> ;
             sosa:isResultOf <urn:test:plot-description-enhanced-protocol-shapes:invalid:fire-history:site-visit> ;
             tern:vocabulary <https://linked.data.gov.au/def/nrm/6e9d2f51-ce64-4c67-8391-d14a8bf96b6b>
         ] ;
-    sosa:hasSimpleResult <https://linked.data.gov.au/def/nrm/b537013e-17bb-5c0c-aa7b-279bcd0e52df> ;
+    sosa:hasSimpleResult <https://linked.data.gov.au/def/nrm/be2897e6-c4ef-49af-973b-f902908939a9> ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/cf1aef8a-a782-4480-9c41-a7f6d170d7fc> ;
     sosa:phenomenonTime <https://example.com/observation/fire-history/b91c54f2-9354-43ee-8412-09974fd2c23c/phenomenonTime> ;
     sosa:resultTime "2022-09-27T05:38:47.117000+00:00"^^xsd:dateTime ;
@@ -122,11 +122,11 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             a
                 tern:IRI ,
                 tern:Value ;
-            rdf:value <https://linked.data.gov.au/def/nrm/b537013e-17bb-5c0c-aa7b-279bcd0e52df> ;
+            rdf:value <https://linked.data.gov.au/def/nrm/be2897e6-c4ef-49af-973b-f902908939a9> ;
             sosa:isResultOf <urn:test:plot-description-enhanced-protocol-shapes:invalid:fire-history:used-procedure> ;
             tern:vocabulary <https://linked.data.gov.au/def/nrm/6e9d2f51-ce64-4c67-8391-d14a8bf96b6b>
         ] ;
-    sosa:hasSimpleResult <https://linked.data.gov.au/def/nrm/b537013e-17bb-5c0c-aa7b-279bcd0e52df> ;
+    sosa:hasSimpleResult <https://linked.data.gov.au/def/nrm/be2897e6-c4ef-49af-973b-f902908939a9> ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/cf1aef8a-a782-4480-9c41-a7f6d170d7fc> ;
     sosa:phenomenonTime <https://example.com/observation/fire-history/b91c54f2-9354-43ee-8412-09974fd2c23c/phenomenonTime> ;
     sosa:resultTime "2022-09-27T05:38:47.117000+00:00"^^xsd:dateTime ;
@@ -145,11 +145,11 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ;
     sosa:hasResult [
             a tern:Value ;
-            rdf:value <https://linked.data.gov.au/def/nrm/b537013e-17bb-5c0c-aa7b-279bcd0e52df> ;
+            rdf:value <https://linked.data.gov.au/def/nrm/be2897e6-c4ef-49af-973b-f902908939a9> ;
             sosa:isResultOf <urn:test:plot-description-enhanced-protocol-shapes:invalid:fire-history:value-type> ;
             tern:vocabulary <https://linked.data.gov.au/def/nrm/6e9d2f51-ce64-4c67-8391-d14a8bf96b6b>
         ] ;
-    sosa:hasSimpleResult <https://linked.data.gov.au/def/nrm/b537013e-17bb-5c0c-aa7b-279bcd0e52df> ;
+    sosa:hasSimpleResult <https://linked.data.gov.au/def/nrm/be2897e6-c4ef-49af-973b-f902908939a9> ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/cf1aef8a-a782-4480-9c41-a7f6d170d7fc> ;
     sosa:phenomenonTime <https://example.com/observation/fire-history/b91c54f2-9354-43ee-8412-09974fd2c23c/phenomenonTime> ;
     sosa:resultTime "2022-09-27T05:38:47.117000+00:00"^^xsd:dateTime ;
@@ -170,11 +170,11 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             a
                 tern:IRI ,
                 tern:Value ;
-            rdf:value <https://linked.data.gov.au/def/nrm/b537013e-17bb-5c0c-aa7b-279bcd0e52df> ;
+            rdf:value <https://linked.data.gov.au/def/nrm/be2897e6-c4ef-49af-973b-f902908939a9> ;
             sosa:isResultOf <urn:test:plot-description-enhanced-protocol-shapes:invalid:fire-history:vocabulary> ;
             tern:vocabulary <urn:fake:vocabulary>
         ] ;
-    sosa:hasSimpleResult <https://linked.data.gov.au/def/nrm/b537013e-17bb-5c0c-aa7b-279bcd0e52df> ;
+    sosa:hasSimpleResult <https://linked.data.gov.au/def/nrm/be2897e6-c4ef-49af-973b-f902908939a9> ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/cf1aef8a-a782-4480-9c41-a7f6d170d7fc> ;
     sosa:phenomenonTime <https://example.com/observation/fire-history/b91c54f2-9354-43ee-8412-09974fd2c23c/phenomenonTime> ;
     sosa:resultTime "2022-09-27T05:38:47.117000+00:00"^^xsd:dateTime ;

--- a/shapes/plot-description/plot-description-enhanced-protocol-shapes/fire-history/shapes.ttl
+++ b/shapes/plot-description/plot-description-enhanced-protocol-shapes/fire-history/shapes.ttl
@@ -46,9 +46,8 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     reg:status reg:statusSubmitted ;
     sh:description "The value in `sosa:hasResult` _MUST_ be a value in `sh:in`, which is the Fire history types controlled vocabulary." ;
     sh:in (
-            <https://linked.data.gov.au/def/nrm/b537013e-17bb-5c0c-aa7b-279bcd0e52df>
-            <https://linked.data.gov.au/def/nrm/f31c4598-bddd-5d42-99f1-4d530f77d4e7>
-            <https://linked.data.gov.au/def/nrm/9a1771c6-6a8e-586d-825d-043d9310fd45>
+            <https://linked.data.gov.au/def/nrm/be2897e6-c4ef-49af-973b-f902908939a9>
+            <https://linked.data.gov.au/def/nrm/f6b0f6d8-16d8-5dd7-b1b7-66b0c020b96f>
         ) ;
     sh:message "The value of `rdf:value` _MUST_ exist in the Fire history types controlled vocabulary." ;
     sh:name "Result value" ;

--- a/shapes/plot-description/plot-description-enhanced-protocol-shapes/fire-history/valid.ttl
+++ b/shapes/plot-description/plot-description-enhanced-protocol-shapes/fire-history/valid.ttl
@@ -18,11 +18,11 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             a
                 tern:IRI ,
                 tern:Value ;
-            rdf:value <https://linked.data.gov.au/def/nrm/b537013e-17bb-5c0c-aa7b-279bcd0e52df> ;
+            rdf:value <https://linked.data.gov.au/def/nrm/be2897e6-c4ef-49af-973b-f902908939a9> ;
             sosa:isResultOf <urn:test:plot-description-enhanced-protocol-shapes:valid:fire-history> ;
             tern:vocabulary <https://linked.data.gov.au/def/nrm/6e9d2f51-ce64-4c67-8391-d14a8bf96b6b>
         ] ;
-    sosa:hasSimpleResult <https://linked.data.gov.au/def/nrm/b537013e-17bb-5c0c-aa7b-279bcd0e52df> ;
+    sosa:hasSimpleResult <https://linked.data.gov.au/def/nrm/be2897e6-c4ef-49af-973b-f902908939a9> ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/cf1aef8a-a782-4480-9c41-a7f6d170d7fc> ;
     sosa:phenomenonTime <https://example.com/observation/fire-history/b91c54f2-9354-43ee-8412-09974fd2c23c/phenomenonTime> ;
     sosa:resultTime "2022-09-27T05:38:47.117000+00:00"^^xsd:dateTime ;

--- a/shapes/plot-description/plot-description-standard-protocol-shapes/fire-history/invalid.ttl
+++ b/shapes/plot-description/plot-description-standard-protocol-shapes/fire-history/invalid.ttl
@@ -23,11 +23,11 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             a
                 tern:IRI ,
                 tern:Value ;
-            rdf:value <https://linked.data.gov.au/def/nrm/b537013e-17bb-5c0c-aa7b-279bcd0e52df> ;
+            rdf:value <https://linked.data.gov.au/def/nrm/be2897e6-c4ef-49af-973b-f902908939a9> ;
             sosa:isResultOf <urn:test:plot-description-standard-protocol-shapes:invalid:fire-history:feature-type> ;
             tern:vocabulary <https://linked.data.gov.au/def/nrm/6e9d2f51-ce64-4c67-8391-d14a8bf96b6b>
         ] ;
-    sosa:hasSimpleResult <https://linked.data.gov.au/def/nrm/b537013e-17bb-5c0c-aa7b-279bcd0e52df> ;
+    sosa:hasSimpleResult <https://linked.data.gov.au/def/nrm/be2897e6-c4ef-49af-973b-f902908939a9> ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/cf1aef8a-a782-4480-9c41-a7f6d170d7fc> ;
     sosa:phenomenonTime <https://example.com/observation/fire-history/b91c54f2-9354-43ee-8412-09974fd2c23c/phenomenonTime> ;
     sosa:resultTime "2022-09-27T05:38:47.117000+00:00"^^xsd:dateTime ;
@@ -73,7 +73,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             a
                 tern:IRI ,
                 tern:Value ;
-            rdf:value <https://linked.data.gov.au/def/nrm/b537013e-17bb-5c0c-aa7b-279bcd0e52df> ;
+            rdf:value <https://linked.data.gov.au/def/nrm/be2897e6-c4ef-49af-973b-f902908939a9> ;
             sosa:isResultOf <urn:test:plot-description-standard-protocol-shapes:invalid:fire-history:simple-result> ;
             tern:vocabulary <https://linked.data.gov.au/def/nrm/6e9d2f51-ce64-4c67-8391-d14a8bf96b6b>
         ] ;
@@ -98,11 +98,11 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             a
                 tern:IRI ,
                 tern:Value ;
-            rdf:value <https://linked.data.gov.au/def/nrm/b537013e-17bb-5c0c-aa7b-279bcd0e52df> ;
+            rdf:value <https://linked.data.gov.au/def/nrm/be2897e6-c4ef-49af-973b-f902908939a9> ;
             sosa:isResultOf <urn:test:plot-description-standard-protocol-shapes:invalid:fire-history:site-visit> ;
             tern:vocabulary <https://linked.data.gov.au/def/nrm/6e9d2f51-ce64-4c67-8391-d14a8bf96b6b>
         ] ;
-    sosa:hasSimpleResult <https://linked.data.gov.au/def/nrm/b537013e-17bb-5c0c-aa7b-279bcd0e52df> ;
+    sosa:hasSimpleResult <https://linked.data.gov.au/def/nrm/be2897e6-c4ef-49af-973b-f902908939a9> ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/cf1aef8a-a782-4480-9c41-a7f6d170d7fc> ;
     sosa:phenomenonTime <https://example.com/observation/fire-history/b91c54f2-9354-43ee-8412-09974fd2c23c/phenomenonTime> ;
     sosa:resultTime "2022-09-27T05:38:47.117000+00:00"^^xsd:dateTime ;
@@ -122,11 +122,11 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             a
                 tern:IRI ,
                 tern:Value ;
-            rdf:value <https://linked.data.gov.au/def/nrm/b537013e-17bb-5c0c-aa7b-279bcd0e52df> ;
+            rdf:value <https://linked.data.gov.au/def/nrm/be2897e6-c4ef-49af-973b-f902908939a9> ;
             sosa:isResultOf <urn:test:plot-description-standard-protocol-shapes:invalid:fire-history:used-procedure> ;
             tern:vocabulary <https://linked.data.gov.au/def/nrm/6e9d2f51-ce64-4c67-8391-d14a8bf96b6b>
         ] ;
-    sosa:hasSimpleResult <https://linked.data.gov.au/def/nrm/b537013e-17bb-5c0c-aa7b-279bcd0e52df> ;
+    sosa:hasSimpleResult <https://linked.data.gov.au/def/nrm/be2897e6-c4ef-49af-973b-f902908939a9> ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/cf1aef8a-a782-4480-9c41-a7f6d170d7fc> ;
     sosa:phenomenonTime <https://example.com/observation/fire-history/b91c54f2-9354-43ee-8412-09974fd2c23c/phenomenonTime> ;
     sosa:resultTime "2022-09-27T05:38:47.117000+00:00"^^xsd:dateTime ;
@@ -145,11 +145,11 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ;
     sosa:hasResult [
             a tern:Value ;
-            rdf:value <https://linked.data.gov.au/def/nrm/b537013e-17bb-5c0c-aa7b-279bcd0e52df> ;
+            rdf:value <https://linked.data.gov.au/def/nrm/be2897e6-c4ef-49af-973b-f902908939a9> ;
             sosa:isResultOf <urn:test:plot-description-standard-protocol-shapes:invalid:fire-history:value-type> ;
             tern:vocabulary <https://linked.data.gov.au/def/nrm/6e9d2f51-ce64-4c67-8391-d14a8bf96b6b>
         ] ;
-    sosa:hasSimpleResult <https://linked.data.gov.au/def/nrm/b537013e-17bb-5c0c-aa7b-279bcd0e52df> ;
+    sosa:hasSimpleResult <https://linked.data.gov.au/def/nrm/be2897e6-c4ef-49af-973b-f902908939a9> ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/cf1aef8a-a782-4480-9c41-a7f6d170d7fc> ;
     sosa:phenomenonTime <https://example.com/observation/fire-history/b91c54f2-9354-43ee-8412-09974fd2c23c/phenomenonTime> ;
     sosa:resultTime "2022-09-27T05:38:47.117000+00:00"^^xsd:dateTime ;
@@ -170,11 +170,11 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             a
                 tern:IRI ,
                 tern:Value ;
-            rdf:value <https://linked.data.gov.au/def/nrm/b537013e-17bb-5c0c-aa7b-279bcd0e52df> ;
+            rdf:value <https://linked.data.gov.au/def/nrm/be2897e6-c4ef-49af-973b-f902908939a9> ;
             sosa:isResultOf <urn:test:plot-description-standard-protocol-shapes:invalid:fire-history:vocabulary> ;
             tern:vocabulary <urn:fake:vocabulary>
         ] ;
-    sosa:hasSimpleResult <https://linked.data.gov.au/def/nrm/b537013e-17bb-5c0c-aa7b-279bcd0e52df> ;
+    sosa:hasSimpleResult <https://linked.data.gov.au/def/nrm/be2897e6-c4ef-49af-973b-f902908939a9> ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/cf1aef8a-a782-4480-9c41-a7f6d170d7fc> ;
     sosa:phenomenonTime <https://example.com/observation/fire-history/b91c54f2-9354-43ee-8412-09974fd2c23c/phenomenonTime> ;
     sosa:resultTime "2022-09-27T05:38:47.117000+00:00"^^xsd:dateTime ;

--- a/shapes/plot-description/plot-description-standard-protocol-shapes/fire-history/shapes.ttl
+++ b/shapes/plot-description/plot-description-standard-protocol-shapes/fire-history/shapes.ttl
@@ -46,9 +46,8 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     reg:status reg:statusSubmitted ;
     sh:description "The value in `sosa:hasResult` _MUST_ be a value in `sh:in`, which is the Fire history types controlled vocabulary." ;
     sh:in (
-            <https://linked.data.gov.au/def/nrm/b537013e-17bb-5c0c-aa7b-279bcd0e52df>
-            <https://linked.data.gov.au/def/nrm/f31c4598-bddd-5d42-99f1-4d530f77d4e7>
-            <https://linked.data.gov.au/def/nrm/9a1771c6-6a8e-586d-825d-043d9310fd45>
+            <https://linked.data.gov.au/def/nrm/be2897e6-c4ef-49af-973b-f902908939a9>
+            <https://linked.data.gov.au/def/nrm/f6b0f6d8-16d8-5dd7-b1b7-66b0c020b96f>
         ) ;
     sh:message "The value of `rdf:value` _MUST_ exist in the Fire history types controlled vocabulary." ;
     sh:name "Result value" ;

--- a/shapes/plot-description/plot-description-standard-protocol-shapes/fire-history/valid.ttl
+++ b/shapes/plot-description/plot-description-standard-protocol-shapes/fire-history/valid.ttl
@@ -18,11 +18,11 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             a
                 tern:IRI ,
                 tern:Value ;
-            rdf:value <https://linked.data.gov.au/def/nrm/b537013e-17bb-5c0c-aa7b-279bcd0e52df> ;
+            rdf:value <https://linked.data.gov.au/def/nrm/be2897e6-c4ef-49af-973b-f902908939a9> ;
             sosa:isResultOf <urn:test:plot-description-standard-protocol-shapes:valid:fire-history> ;
             tern:vocabulary <https://linked.data.gov.au/def/nrm/6e9d2f51-ce64-4c67-8391-d14a8bf96b6b>
         ] ;
-    sosa:hasSimpleResult <https://linked.data.gov.au/def/nrm/b537013e-17bb-5c0c-aa7b-279bcd0e52df> ;
+    sosa:hasSimpleResult <https://linked.data.gov.au/def/nrm/be2897e6-c4ef-49af-973b-f902908939a9> ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/cf1aef8a-a782-4480-9c41-a7f6d170d7fc> ;
     sosa:phenomenonTime <https://example.com/observation/fire-history/b91c54f2-9354-43ee-8412-09974fd2c23c/phenomenonTime> ;
     sosa:resultTime "2022-09-27T05:38:47.117000+00:00"^^xsd:dateTime ;

--- a/shapes/vegetation-mapping-protocol-shapes/fire-history/invalid.ttl
+++ b/shapes/vegetation-mapping-protocol-shapes/fire-history/invalid.ttl
@@ -23,11 +23,11 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             a
                 tern:IRI ,
                 tern:Value ;
-            rdf:value <https://linked.data.gov.au/def/nrm/b537013e-17bb-5c0c-aa7b-279bcd0e52df> ;
+            rdf:value <https://linked.data.gov.au/def/nrm/be2897e6-c4ef-49af-973b-f902908939a9> ;
             sosa:isResultOf <urn:test:vegetation-mapping-protocol-shapes:invalid:fire-history:feature-type> ;
             tern:vocabulary <https://linked.data.gov.au/def/nrm/6e9d2f51-ce64-4c67-8391-d14a8bf96b6b>
         ] ;
-    sosa:hasSimpleResult <https://linked.data.gov.au/def/nrm/b537013e-17bb-5c0c-aa7b-279bcd0e52df> ;
+    sosa:hasSimpleResult <https://linked.data.gov.au/def/nrm/be2897e6-c4ef-49af-973b-f902908939a9> ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/cf1aef8a-a782-4480-9c41-a7f6d170d7fc> ;
     sosa:phenomenonTime <https://example.com/observation/fire-history/b91c54f2-9354-43ee-8412-09974fd2c23c/phenomenonTime> ;
     sosa:resultTime "2022-09-27T05:38:47.117000+00:00"^^xsd:dateTime ;
@@ -71,7 +71,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             a
                 tern:IRI ,
                 tern:Value ;
-            rdf:value <https://linked.data.gov.au/def/nrm/b537013e-17bb-5c0c-aa7b-279bcd0e52df> ;
+            rdf:value <https://linked.data.gov.au/def/nrm/be2897e6-c4ef-49af-973b-f902908939a9> ;
             sosa:isResultOf <urn:test:vegetation-mapping-protocol-shapes:invalid:fire-history:simple-result> ;
             tern:vocabulary <https://linked.data.gov.au/def/nrm/6e9d2f51-ce64-4c67-8391-d14a8bf96b6b>
         ] ;
@@ -95,11 +95,11 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             a
                 tern:IRI ,
                 tern:Value ;
-            rdf:value <https://linked.data.gov.au/def/nrm/b537013e-17bb-5c0c-aa7b-279bcd0e52df> ;
+            rdf:value <https://linked.data.gov.au/def/nrm/be2897e6-c4ef-49af-973b-f902908939a9> ;
             sosa:isResultOf <urn:test:vegetation-mapping-protocol-shapes:invalid:fire-history:used-procedure> ;
             tern:vocabulary <https://linked.data.gov.au/def/nrm/6e9d2f51-ce64-4c67-8391-d14a8bf96b6b>
         ] ;
-    sosa:hasSimpleResult <https://linked.data.gov.au/def/nrm/b537013e-17bb-5c0c-aa7b-279bcd0e52df> ;
+    sosa:hasSimpleResult <https://linked.data.gov.au/def/nrm/be2897e6-c4ef-49af-973b-f902908939a9> ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/cf1aef8a-a782-4480-9c41-a7f6d170d7fc> ;
     sosa:phenomenonTime <https://example.com/observation/fire-history/b91c54f2-9354-43ee-8412-09974fd2c23c/phenomenonTime> ;
     sosa:resultTime "2022-09-27T05:38:47.117000+00:00"^^xsd:dateTime ;
@@ -117,11 +117,11 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ;
     sosa:hasResult [
             a tern:Value ;
-            rdf:value <https://linked.data.gov.au/def/nrm/b537013e-17bb-5c0c-aa7b-279bcd0e52df> ;
+            rdf:value <https://linked.data.gov.au/def/nrm/be2897e6-c4ef-49af-973b-f902908939a9> ;
             sosa:isResultOf <urn:test:vegetation-mapping-protocol-shapes:invalid:fire-history:value-type> ;
             tern:vocabulary <https://linked.data.gov.au/def/nrm/6e9d2f51-ce64-4c67-8391-d14a8bf96b6b>
         ] ;
-    sosa:hasSimpleResult <https://linked.data.gov.au/def/nrm/b537013e-17bb-5c0c-aa7b-279bcd0e52df> ;
+    sosa:hasSimpleResult <https://linked.data.gov.au/def/nrm/be2897e6-c4ef-49af-973b-f902908939a9> ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/cf1aef8a-a782-4480-9c41-a7f6d170d7fc> ;
     sosa:phenomenonTime <https://example.com/observation/fire-history/b91c54f2-9354-43ee-8412-09974fd2c23c/phenomenonTime> ;
     sosa:resultTime "2022-09-27T05:38:47.117000+00:00"^^xsd:dateTime ;
@@ -141,11 +141,11 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             a
                 tern:IRI ,
                 tern:Value ;
-            rdf:value <https://linked.data.gov.au/def/nrm/b537013e-17bb-5c0c-aa7b-279bcd0e52df> ;
+            rdf:value <https://linked.data.gov.au/def/nrm/be2897e6-c4ef-49af-973b-f902908939a9> ;
             sosa:isResultOf <urn:test:vegetation-mapping-protocol-shapes:invalid:fire-history:vocabulary> ;
             tern:vocabulary <urn:fake:vocabulary>
         ] ;
-    sosa:hasSimpleResult <https://linked.data.gov.au/def/nrm/b537013e-17bb-5c0c-aa7b-279bcd0e52df> ;
+    sosa:hasSimpleResult <https://linked.data.gov.au/def/nrm/be2897e6-c4ef-49af-973b-f902908939a9> ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/cf1aef8a-a782-4480-9c41-a7f6d170d7fc> ;
     sosa:phenomenonTime <https://example.com/observation/fire-history/b91c54f2-9354-43ee-8412-09974fd2c23c/phenomenonTime> ;
     sosa:resultTime "2022-09-27T05:38:47.117000+00:00"^^xsd:dateTime ;

--- a/shapes/vegetation-mapping-protocol-shapes/fire-history/shapes.ttl
+++ b/shapes/vegetation-mapping-protocol-shapes/fire-history/shapes.ttl
@@ -46,9 +46,8 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     reg:status reg:statusSubmitted ;
     sh:description "The value in `sosa:hasResult` _MUST_ be a value in `sh:in`, which is the Fire history types controlled vocabulary." ;
     sh:in (
-            <https://linked.data.gov.au/def/nrm/b537013e-17bb-5c0c-aa7b-279bcd0e52df>
-            <https://linked.data.gov.au/def/nrm/f31c4598-bddd-5d42-99f1-4d530f77d4e7>
-            <https://linked.data.gov.au/def/nrm/9a1771c6-6a8e-586d-825d-043d9310fd45>
+            <https://linked.data.gov.au/def/nrm/be2897e6-c4ef-49af-973b-f902908939a9>
+            <https://linked.data.gov.au/def/nrm/f6b0f6d8-16d8-5dd7-b1b7-66b0c020b96f>
         ) ;
     sh:message "The value of `rdf:value` _MUST_ exist in the Fire history types controlled vocabulary." ;
     sh:name "Result value" ;

--- a/shapes/vegetation-mapping-protocol-shapes/fire-history/valid.ttl
+++ b/shapes/vegetation-mapping-protocol-shapes/fire-history/valid.ttl
@@ -23,11 +23,11 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             a
                 tern:IRI ,
                 tern:Value ;
-            rdf:value <https://linked.data.gov.au/def/nrm/b537013e-17bb-5c0c-aa7b-279bcd0e52df> ;
+            rdf:value <https://linked.data.gov.au/def/nrm/be2897e6-c4ef-49af-973b-f902908939a9> ;
             sosa:isResultOf <urn:test:vegetation-mapping-protocol-shapes:valid:fire-history> ;
             tern:vocabulary <https://linked.data.gov.au/def/nrm/6e9d2f51-ce64-4c67-8391-d14a8bf96b6b>
         ] ;
-    sosa:hasSimpleResult <https://linked.data.gov.au/def/nrm/b537013e-17bb-5c0c-aa7b-279bcd0e52df> ;
+    sosa:hasSimpleResult <https://linked.data.gov.au/def/nrm/be2897e6-c4ef-49af-973b-f902908939a9> ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/cf1aef8a-a782-4480-9c41-a7f6d170d7fc> ;
     sosa:phenomenonTime <https://example.com/observation/fire-history/b91c54f2-9354-43ee-8412-09974fd2c23c/phenomenonTime> ;
     sosa:resultTime "2022-09-27T05:38:47.117000+00:00"^^xsd:dateTime ;


### PR DESCRIPTION
This PR updated SHACL shapes for using the updated Categorical Values for fire-history in the folowwing 3 protocols:

- vegetation-mapping
- plot-description-enhanced
- plot-description-standard