### PR TITLE
Updated the Datatype (float to integer), units and feature_types in SHACL shapes for multiple modules

### DIFF
--- a/shapes/opportunistic-observations-protocol-shapes/field-species-name/shapes.ttl
+++ b/shapes/opportunistic-observations-protocol-shapes/field-species-name/shapes.ttl
@@ -42,9 +42,12 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         urnc:Requirement ;
     dcterms:source "Ecological Monitoring System - Australia Protocols" ;
     reg:status reg:statusSubmitted ;
-    sh:description "TERN's ecologists have determined the feature type is _plant occurrence_, defined by the link:https://www.publish.csiro.au/book/5230/[Australian Soil and Land Survey Field Handbook]." ;
-    sh:hasValue <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> ;
-    sh:message "The value of `tern:featureType` _MUST_ be link: http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611[`plant occurrence`]." ;
+    sh:description "TERN's ecologists have determined the feature type is either _plant occurrence_ or _animal occurrence_, defined by the link:https://www.publish.csiro.au/book/5230/[Australian Soil and Land Survey Field Handbook]." ;
+    sh:in (
+        <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611>
+        <http://linked.data.gov.au/def/tern-cv/2361dea8-598c-4b6f-a641-2b98ff199e9e>
+    ) ;
+    sh:message "The value of `tern:featureType` _MUST_ be link:http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611[`plant occurrence`] or link:http://linked.data.gov.au/def/tern-cv/2361dea8-598c-4b6f-a641-2b98ff199e9e[`animal occurrence`]." ;
     sh:name "Feature type" ;
     sh:path tern:featureType ;
     sh:target [

--- a/shapes/opportunistic-observations-protocol-shapes/taxa-type/shapes.ttl
+++ b/shapes/opportunistic-observations-protocol-shapes/taxa-type/shapes.ttl
@@ -14,9 +14,12 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         urnc:Requirement ;
     dcterms:source "Ecological Monitoring System - Australia Protocols" ;
     reg:status reg:statusSubmitted ;
-    sh:description "TERN's ecologists have determined the feature type is _plant occurrence_, defined by the link:https://www.publish.csiro.au/book/5230/[Australian Soil and Land Survey Field Handbook]." ;
-    sh:hasValue <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> ;
-    sh:message "The value of `tern:featureType` _MUST_ be link: http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611[`plant occurrence`]." ;
+    sh:description "TERN's ecologists have determined the feature type is either _plant occurrence_ or _animal occurrence_, defined by the link:https://www.publish.csiro.au/book/5230/[Australian Soil and Land Survey Field Handbook]." ;
+    sh:in (
+        <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611>
+        <http://linked.data.gov.au/def/tern-cv/2361dea8-598c-4b6f-a641-2b98ff199e9e>
+    ) ;
+    sh:message "The value of `tern:featureType` _MUST_ be link:http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611[`plant occurrence`] or link:http://linked.data.gov.au/def/tern-cv/2361dea8-598c-4b6f-a641-2b98ff199e9e[`animal occurrence`]." ;
     sh:name "Feature type" ;
     sh:path tern:featureType ;
     sh:target [

--- a/shapes/plot-description/plot-description-enhanced-protocol-shapes/aspect/invalid.ttl
+++ b/shapes/plot-description/plot-description-enhanced-protocol-shapes/aspect/invalid.ttl
@@ -14,7 +14,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <urn:test:plot-description-enhanced-protocol-shapes:invalid:aspect:datatype>
     a tern:Observation ;
     void:inDataset <https://example.com/dataset/1> ;
-    rdfs:comment "Invalid result - the datatype of the value of the result node must be `xsd:float`." ;
+    rdfs:comment "Invalid result - the datatype of the value of the result node must be `xsd:integer`." ;
     sosa:hasFeatureOfInterest [
             a tern:FeatureOfInterest ;
             void:inDataset <https://example.com/dataset/1> ;
@@ -22,13 +22,13 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ;
     sosa:hasResult [
             a
-                tern:Float ,
+                tern:Integer ,
                 tern:Value ;
-            rdf:value 3 ;
+            rdf:value "33.81"^^xsd:float ;
             sosa:isResultOf <urn:test:plot-description-enhanced-protocol-shapes:invalid:aspect:datatype> ;
             tern:unit unit:DEG
         ] ;
-    sosa:hasSimpleResult 3 ;
+    sosa:hasSimpleResult "33.81"^^xsd:float ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/0e0423c6-0dc3-40aa-9776-410a94299256> ;
     sosa:phenomenonTime <https://example.com/observation/aspect/b91c54f2-9354-43ee-8412-09974fd2c23c/phenomenonTime> ;
     sosa:resultTime "2022-09-27T05:38:47.117000+00:00"^^xsd:dateTime ;
@@ -47,13 +47,13 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ;
     sosa:hasResult [
             a
-                tern:Float ,
+                tern:Integer ,
                 tern:Value ;
-            rdf:value "33.81"^^xsd:float ;
+            rdf:value 33 ;
             sosa:isResultOf <urn:test:plot-description-enhanced-protocol-shapes:invalid:aspect:feature-type> ;
             tern:unit unit:DEG
         ] ;
-    sosa:hasSimpleResult "33.81"^^xsd:float ;
+    sosa:hasSimpleResult 33 ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/0e0423c6-0dc3-40aa-9776-410a94299256> ;
     sosa:phenomenonTime <https://example.com/observation/aspect/b91c54f2-9354-43ee-8412-09974fd2c23c/phenomenonTime> ;
     sosa:resultTime "2022-09-27T05:38:47.117000+00:00"^^xsd:dateTime ;
@@ -72,13 +72,13 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ;
     sosa:hasResult [
             a
-                tern:Float ,
+                tern:Integer ,
                 tern:Value ;
-            rdf:value "33.81"^^xsd:float ;
+            rdf:value 33 ;
             sosa:isResultOf <urn:test:plot-description-enhanced-protocol-shapes:invalid:aspect:simple-result> ;
             tern:unit unit:DEG
         ] ;
-    sosa:hasSimpleResult "13.56"^^xsd:float ;
+    sosa:hasSimpleResult 13 ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/0e0423c6-0dc3-40aa-9776-410a94299256> ;
     sosa:phenomenonTime <https://example.com/observation/aspect/b91c54f2-9354-43ee-8412-09974fd2c23c/phenomenonTime> ;
     sosa:resultTime "2022-09-27T05:38:47.117000+00:00"^^xsd:dateTime ;
@@ -97,13 +97,13 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ;
     sosa:hasResult [
             a
-                tern:Float ,
+                tern:Integer ,
                 tern:Value ;
-            rdf:value "33.81"^^xsd:float ;
+            rdf:value 33 ;
             sosa:isResultOf <urn:test:plot-description-enhanced-protocol-shapes:invalid:aspect:site-visit> ;
             tern:unit unit:DEG
         ] ;
-    sosa:hasSimpleResult "33.81"^^xsd:float ;
+    sosa:hasSimpleResult 33 ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/0e0423c6-0dc3-40aa-9776-410a94299256> ;
     sosa:phenomenonTime <https://example.com/observation/aspect/b91c54f2-9354-43ee-8412-09974fd2c23c/phenomenonTime> ;
     sosa:resultTime "2022-09-27T05:38:47.117000+00:00"^^xsd:dateTime ;
@@ -121,13 +121,13 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ;
     sosa:hasResult [
             a
-                tern:Float ,
+                tern:Integer ,
                 tern:Value ;
-            rdf:value "33.81"^^xsd:float ;
+            rdf:value 33 ;
             sosa:isResultOf <urn:test:plot-description-enhanced-protocol-shapes:invalid:aspect:unit-of-measure> ;
             tern:unit <urn:fake:unit>
         ] ;
-    sosa:hasSimpleResult "33.81"^^xsd:float ;
+    sosa:hasSimpleResult 33 ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/0e0423c6-0dc3-40aa-9776-410a94299256> ;
     sosa:phenomenonTime <https://example.com/observation/aspect/b91c54f2-9354-43ee-8412-09974fd2c23c/phenomenonTime> ;
     sosa:resultTime "2022-09-27T05:38:47.117000+00:00"^^xsd:dateTime ;
@@ -146,13 +146,13 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ;
     sosa:hasResult [
             a
-                tern:Float ,
+                tern:Integer ,
                 tern:Value ;
-            rdf:value "33.81"^^xsd:float ;
+            rdf:value 33 ;
             sosa:isResultOf <urn:test:plot-description-enhanced-protocol-shapes:invalid:aspect:used-procedure> ;
             tern:unit unit:DEG
         ] ;
-    sosa:hasSimpleResult "33.81"^^xsd:float ;
+    sosa:hasSimpleResult 33 ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/0e0423c6-0dc3-40aa-9776-410a94299256> ;
     sosa:phenomenonTime <https://example.com/observation/aspect/b91c54f2-9354-43ee-8412-09974fd2c23c/phenomenonTime> ;
     sosa:resultTime "2022-09-27T05:38:47.117000+00:00"^^xsd:dateTime ;
@@ -171,13 +171,13 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ;
     sosa:hasResult [
             a
-                tern:Float ,
+                tern:Integer ,
                 tern:Value ;
-            rdf:value "-1.11"^^xsd:float ;
+            rdf:value -1 ;
             sosa:isResultOf <urn:test:plot-description-enhanced-protocol-shapes:invalid:aspect:value-range> ;
             tern:unit unit:DEG
         ] ;
-    sosa:hasSimpleResult "-1.11"^^xsd:float ;
+    sosa:hasSimpleResult -1 ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/0e0423c6-0dc3-40aa-9776-410a94299256> ;
     sosa:phenomenonTime <https://example.com/observation/aspect/b91c54f2-9354-43ee-8412-09974fd2c23c/phenomenonTime> ;
     sosa:resultTime "2022-09-27T05:38:47.117000+00:00"^^xsd:dateTime ;
@@ -188,7 +188,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <urn:test:plot-description-enhanced-protocol-shapes:invalid:aspect:value-type>
     a tern:Observation ;
     void:inDataset <https://example.com/dataset/1> ;
-    rdfs:comment "Invalid result - the value of the result node must be `tern:Float`." ;
+    rdfs:comment "Invalid result - the value of the result node must be `tern:Integer`." ;
     sosa:hasFeatureOfInterest [
             a tern:FeatureOfInterest ;
             void:inDataset <https://example.com/dataset/1> ;
@@ -196,11 +196,11 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ;
     sosa:hasResult [
             a tern:Value ;
-            rdf:value "33.81"^^xsd:float ;
+            rdf:value 33 ;
             sosa:isResultOf <urn:test:plot-description-enhanced-protocol-shapes:invalid:aspect:value-type> ;
             tern:unit unit:DEG
         ] ;
-    sosa:hasSimpleResult "33.81"^^xsd:float ;
+    sosa:hasSimpleResult 33 ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/0e0423c6-0dc3-40aa-9776-410a94299256> ;
     sosa:phenomenonTime <https://example.com/observation/aspect/b91c54f2-9354-43ee-8412-09974fd2c23c/phenomenonTime> ;
     sosa:resultTime "2022-09-27T05:38:47.117000+00:00"^^xsd:dateTime ;

--- a/shapes/plot-description/plot-description-enhanced-protocol-shapes/aspect/shapes.ttl
+++ b/shapes/plot-description/plot-description-enhanced-protocol-shapes/aspect/shapes.ttl
@@ -166,7 +166,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         urnc:Requirement ;
     dcterms:source "Ecological Monitoring System - Australia Protocols" ;
     reg:status reg:statusSubmitted ;
-    sh:datatype xsd:float ;
+    sh:datatype xsd:integer ;
     sh:description "Value _MUST_ be between 0 exclusive and 360 inclusive." ;
     sh:maxInclusive 360 ;
     sh:message "The result _MUST_ have a value between 0 exclusive and 360 inclusive." ;
@@ -196,9 +196,9 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         urnc:Requirement ;
     dcterms:source "Ecological Monitoring System - Australia Protocols" ;
     reg:status reg:statusSubmitted ;
-    sh:class tern:Float ;
-    sh:description "The value of `sosa:hasResult` _MUST_ be a `tern:Float`." ;
-    sh:message "The result _MUST_ be an instance of `tern:Float`." ;
+    sh:class tern:Integer ;
+    sh:description "The value of `sosa:hasResult` _MUST_ be a `tern:Integer`." ;
+    sh:message "The result _MUST_ be an instance of `tern:Integer`." ;
     sh:name "Value type" ;
     sh:path sosa:hasResult ;
     sh:target [

--- a/shapes/plot-description/plot-description-enhanced-protocol-shapes/aspect/valid.ttl
+++ b/shapes/plot-description/plot-description-enhanced-protocol-shapes/aspect/valid.ttl
@@ -17,13 +17,13 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ;
     sosa:hasResult [
             a
-                tern:Float ,
+                tern:Integer ,
                 tern:Value ;
-            rdf:value "33.81"^^xsd:float ;
+            rdf:value 33 ;
             sosa:isResultOf <urn:test:plot-description-enhanced-protocol-shapes:valid:aspect> ;
             tern:unit unit:DEG
         ] ;
-    sosa:hasSimpleResult "33.81"^^xsd:float ;
+    sosa:hasSimpleResult 33 ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/0e0423c6-0dc3-40aa-9776-410a94299256> ;
     sosa:phenomenonTime <https://example.com/observation/aspect/b91c54f2-9354-43ee-8412-09974fd2c23c/phenomenonTime> ;
     sosa:resultTime "2022-09-27T05:38:47.117000+00:00"^^xsd:dateTime ;

--- a/shapes/plot-description/plot-description-enhanced-protocol-shapes/homogeneity-measure/invalid.ttl
+++ b/shapes/plot-description/plot-description-enhanced-protocol-shapes/homogeneity-measure/invalid.ttl
@@ -14,7 +14,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <urn:test:plot-description-enhanced-protocol-shapes:invalid:homogeneity-measure:datatype>
     a tern:Observation ;
     void:inDataset <https://example.com/dataset/1> ;
-    rdfs:comment "Invalid result - the datatype of the value of the result node must be `xsd:float`." ;
+    rdfs:comment "Invalid result - the datatype of the value of the result node must be `xsd:integer`." ;
     sosa:hasFeatureOfInterest [
             a tern:FeatureOfInterest ;
             void:inDataset <https://example.com/dataset/1> ;
@@ -22,13 +22,13 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ;
     sosa:hasResult [
             a
-                tern:Float ,
+                tern:Integer ,
                 tern:Value ;
-            rdf:value 3 ;
+            rdf:value "33.81"^^xsd:float ;
             sosa:isResultOf <urn:test:plot-description-enhanced-protocol-shapes:invalid:homogeneity-measure:datatype> ;
             tern:unit unit:M
         ] ;
-    sosa:hasSimpleResult 3 ;
+    sosa:hasSimpleResult "33.81"^^xsd:float ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/325d5ff2-8c81-484a-a422-c13ff29666a9> ;
     sosa:phenomenonTime <https://example.com/observation/homogeneity-measure/b91c54f2-9354-43ee-8412-09974fd2c23c/phenomenonTime> ;
     sosa:resultTime "2022-09-27T05:38:47.117000+00:00"^^xsd:dateTime ;
@@ -47,13 +47,13 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ;
     sosa:hasResult [
             a
-                tern:Float ,
+                tern:Integer ,
                 tern:Value ;
-            rdf:value "33.81"^^xsd:float ;
+            rdf:value 33 ;
             sosa:isResultOf <urn:test:plot-description-enhanced-protocol-shapes:invalid:homogeneity-measure:feature-type> ;
             tern:unit unit:M
         ] ;
-    sosa:hasSimpleResult "33.81"^^xsd:float ;
+    sosa:hasSimpleResult 33 ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/325d5ff2-8c81-484a-a422-c13ff29666a9> ;
     sosa:phenomenonTime <https://example.com/observation/homogeneity-measure/b91c54f2-9354-43ee-8412-09974fd2c23c/phenomenonTime> ;
     sosa:resultTime "2022-09-27T05:38:47.117000+00:00"^^xsd:dateTime ;
@@ -72,13 +72,13 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ;
     sosa:hasResult [
             a
-                tern:Float ,
+                tern:Integer ,
                 tern:Value ;
-            rdf:value "33.81"^^xsd:float ;
+            rdf:value 33 ;
             sosa:isResultOf <urn:test:plot-description-enhanced-protocol-shapes:invalid:homogeneity-measure:simple-result> ;
             tern:unit unit:M
         ] ;
-    sosa:hasSimpleResult "13.56"^^xsd:float ;
+    sosa:hasSimpleResult 13 ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/325d5ff2-8c81-484a-a422-c13ff29666a9> ;
     sosa:phenomenonTime <https://example.com/observation/homogeneity-measure/b91c54f2-9354-43ee-8412-09974fd2c23c/phenomenonTime> ;
     sosa:resultTime "2022-09-27T05:38:47.117000+00:00"^^xsd:dateTime ;
@@ -97,13 +97,13 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ;
     sosa:hasResult [
             a
-                tern:Float ,
+                tern:Integer ,
                 tern:Value ;
-            rdf:value "33.81"^^xsd:float ;
+            rdf:value 33 ;
             sosa:isResultOf <urn:test:plot-description-enhanced-protocol-shapes:invalid:homogeneity-measure:site-visit> ;
             tern:unit unit:M
         ] ;
-    sosa:hasSimpleResult "33.81"^^xsd:float ;
+    sosa:hasSimpleResult 33 ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/325d5ff2-8c81-484a-a422-c13ff29666a9> ;
     sosa:phenomenonTime <https://example.com/observation/homogeneity-measure/b91c54f2-9354-43ee-8412-09974fd2c23c/phenomenonTime> ;
     sosa:resultTime "2022-09-27T05:38:47.117000+00:00"^^xsd:dateTime ;
@@ -121,13 +121,13 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ;
     sosa:hasResult [
             a
-                tern:Float ,
+                tern:Integer ,
                 tern:Value ;
-            rdf:value "33.81"^^xsd:float ;
+            rdf:value 33 ;
             sosa:isResultOf <urn:test:plot-description-enhanced-protocol-shapes:invalid:homogeneity-measure:unit-of-measure> ;
             tern:unit <urn:fake:unit>
         ] ;
-    sosa:hasSimpleResult "33.81"^^xsd:float ;
+    sosa:hasSimpleResult 33 ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/325d5ff2-8c81-484a-a422-c13ff29666a9> ;
     sosa:phenomenonTime <https://example.com/observation/homogeneity-measure/b91c54f2-9354-43ee-8412-09974fd2c23c/phenomenonTime> ;
     sosa:resultTime "2022-09-27T05:38:47.117000+00:00"^^xsd:dateTime ;
@@ -146,13 +146,13 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ;
     sosa:hasResult [
             a
-                tern:Float ,
+                tern:Integer ,
                 tern:Value ;
-            rdf:value "33.81"^^xsd:float ;
+            rdf:value 33 ;
             sosa:isResultOf <urn:test:plot-description-enhanced-protocol-shapes:invalid:homogeneity-measure:used-procedure> ;
             tern:unit unit:M
         ] ;
-    sosa:hasSimpleResult "33.81"^^xsd:float ;
+    sosa:hasSimpleResult 33 ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/325d5ff2-8c81-484a-a422-c13ff29666a9> ;
     sosa:phenomenonTime <https://example.com/observation/homogeneity-measure/b91c54f2-9354-43ee-8412-09974fd2c23c/phenomenonTime> ;
     sosa:resultTime "2022-09-27T05:38:47.117000+00:00"^^xsd:dateTime ;
@@ -171,13 +171,13 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ;
     sosa:hasResult [
             a
-                tern:Float ,
+                tern:Integer ,
                 tern:Value ;
-            rdf:value "-1.11"^^xsd:float ;
+            rdf:value -1 ;
             sosa:isResultOf <urn:test:plot-description-enhanced-protocol-shapes:invalid:homogeneity-measure:value-range> ;
             tern:unit unit:M
         ] ;
-    sosa:hasSimpleResult "-1.11"^^xsd:float ;
+    sosa:hasSimpleResult -1 ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/325d5ff2-8c81-484a-a422-c13ff29666a9> ;
     sosa:phenomenonTime <https://example.com/observation/homogeneity-measure/b91c54f2-9354-43ee-8412-09974fd2c23c/phenomenonTime> ;
     sosa:resultTime "2022-09-27T05:38:47.117000+00:00"^^xsd:dateTime ;
@@ -188,7 +188,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <urn:test:plot-description-enhanced-protocol-shapes:invalid:homogeneity-measure:value-type>
     a tern:Observation ;
     void:inDataset <https://example.com/dataset/1> ;
-    rdfs:comment "Invalid result - the value of the result node must be `tern:Float`." ;
+    rdfs:comment "Invalid result - the value of the result node must be `tern:Integer`." ;
     sosa:hasFeatureOfInterest [
             a tern:FeatureOfInterest ;
             void:inDataset <https://example.com/dataset/1> ;
@@ -196,11 +196,11 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ;
     sosa:hasResult [
             a tern:Value ;
-            rdf:value "33.81"^^xsd:float ;
+            rdf:value 33 ;
             sosa:isResultOf <urn:test:plot-description-enhanced-protocol-shapes:invalid:homogeneity-measure:value-type> ;
             tern:unit unit:M
         ] ;
-    sosa:hasSimpleResult "33.81"^^xsd:float ;
+    sosa:hasSimpleResult 33 ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/325d5ff2-8c81-484a-a422-c13ff29666a9> ;
     sosa:phenomenonTime <https://example.com/observation/homogeneity-measure/b91c54f2-9354-43ee-8412-09974fd2c23c/phenomenonTime> ;
     sosa:resultTime "2022-09-27T05:38:47.117000+00:00"^^xsd:dateTime ;

--- a/shapes/plot-description/plot-description-enhanced-protocol-shapes/homogeneity-measure/shapes.ttl
+++ b/shapes/plot-description/plot-description-enhanced-protocol-shapes/homogeneity-measure/shapes.ttl
@@ -166,7 +166,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         urnc:Requirement ;
     dcterms:source "Ecological Monitoring System - Australia Protocols" ;
     reg:status reg:statusSubmitted ;
-    sh:datatype xsd:float ;
+    sh:datatype xsd:integer ;
     sh:description "Value _MUST_ not be negative." ;
     sh:message "The result _MUST_ not be negative." ;
     sh:minInclusive 0 ;
@@ -195,9 +195,9 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         urnc:Requirement ;
     dcterms:source "Ecological Monitoring System - Australia Protocols" ;
     reg:status reg:statusSubmitted ;
-    sh:class tern:Float ;
-    sh:description "The value of `sosa:hasResult` _MUST_ be a `tern:Float`." ;
-    sh:message "The result _MUST_ be an instance of `tern:Float`." ;
+    sh:class tern:Integer ;
+    sh:description "The value of `sosa:hasResult` _MUST_ be a `tern:Integer`." ;
+    sh:message "The result _MUST_ be an instance of `tern:Integer`." ;
     sh:name "Value type" ;
     sh:path sosa:hasResult ;
     sh:target [

--- a/shapes/plot-description/plot-description-enhanced-protocol-shapes/homogeneity-measure/valid.ttl
+++ b/shapes/plot-description/plot-description-enhanced-protocol-shapes/homogeneity-measure/valid.ttl
@@ -17,13 +17,13 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ;
     sosa:hasResult [
             a
-                tern:Float ,
+                tern:Integer ,
                 tern:Value ;
-            rdf:value "33.81"^^xsd:float ;
+            rdf:value 33 ;
             sosa:isResultOf <urn:test:plot-description-enhanced-protocol-shapes:valid:homogeneity-measure> ;
             tern:unit unit:M
         ] ;
-    sosa:hasSimpleResult "33.81"^^xsd:float ;
+    sosa:hasSimpleResult 33 ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/325d5ff2-8c81-484a-a422-c13ff29666a9> ;
     sosa:phenomenonTime <https://example.com/observation/homogeneity-measure/b91c54f2-9354-43ee-8412-09974fd2c23c/phenomenonTime> ;
     sosa:resultTime "2022-09-27T05:38:47.117000+00:00"^^xsd:dateTime ;

--- a/shapes/plot-description/plot-description-enhanced-protocol-shapes/slope/invalid.ttl
+++ b/shapes/plot-description/plot-description-enhanced-protocol-shapes/slope/invalid.ttl
@@ -14,7 +14,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <urn:test:plot-description-enhanced-protocol-shapes:invalid:slope:datatype>
     a tern:Observation ;
     void:inDataset <https://example.com/dataset/1> ;
-    rdfs:comment "Invalid result - the datatype of the value of the result node must be `xsd:float`." ;
+    rdfs:comment "Invalid result - the datatype of the value of the result node must be `xsd:integer`." ;
     sosa:hasFeatureOfInterest [
             a tern:FeatureOfInterest ;
             void:inDataset <https://example.com/dataset/1> ;
@@ -22,13 +22,13 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ;
     sosa:hasResult [
             a
-                tern:Float ,
+                tern:Integer ,
                 tern:Value ;
-            rdf:value 3 ;
+            rdf:value "33.81"^^xsd:float ;
             sosa:isResultOf <urn:test:plot-description-enhanced-protocol-shapes:invalid:slope:datatype> ;
-            tern:unit unit:DEG
+            tern:unit unit:Percent
         ] ;
-    sosa:hasSimpleResult 3 ;
+    sosa:hasSimpleResult "33.81"^^xsd:float ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/b036ba09-d061-4a1c-99a8-890efc462a2c> ;
     sosa:phenomenonTime <https://example.com/observation/slope/b91c54f2-9354-43ee-8412-09974fd2c23c/phenomenonTime> ;
     sosa:resultTime "2022-09-27T05:38:47.117000+00:00"^^xsd:dateTime ;
@@ -47,13 +47,13 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ;
     sosa:hasResult [
             a
-                tern:Float ,
+                tern:Integer ,
                 tern:Value ;
-            rdf:value "33.81"^^xsd:float ;
+            rdf:value 33 ;
             sosa:isResultOf <urn:test:plot-description-enhanced-protocol-shapes:invalid:slope:feature-type> ;
-            tern:unit unit:DEG
+            tern:unit unit:Percent
         ] ;
-    sosa:hasSimpleResult "33.81"^^xsd:float ;
+    sosa:hasSimpleResult 33 ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/b036ba09-d061-4a1c-99a8-890efc462a2c> ;
     sosa:phenomenonTime <https://example.com/observation/slope/b91c54f2-9354-43ee-8412-09974fd2c23c/phenomenonTime> ;
     sosa:resultTime "2022-09-27T05:38:47.117000+00:00"^^xsd:dateTime ;
@@ -72,13 +72,13 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ;
     sosa:hasResult [
             a
-                tern:Float ,
+                tern:Integer ,
                 tern:Value ;
-            rdf:value "33.81"^^xsd:float ;
+            rdf:value 33 ;
             sosa:isResultOf <urn:test:plot-description-enhanced-protocol-shapes:invalid:slope:simple-result> ;
-            tern:unit unit:DEG
+            tern:unit unit:Percent
         ] ;
-    sosa:hasSimpleResult "13.56"^^xsd:float ;
+    sosa:hasSimpleResult 13 ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/b036ba09-d061-4a1c-99a8-890efc462a2c> ;
     sosa:phenomenonTime <https://example.com/observation/slope/b91c54f2-9354-43ee-8412-09974fd2c23c/phenomenonTime> ;
     sosa:resultTime "2022-09-27T05:38:47.117000+00:00"^^xsd:dateTime ;
@@ -97,13 +97,13 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ;
     sosa:hasResult [
             a
-                tern:Float ,
+                tern:Integer ,
                 tern:Value ;
-            rdf:value "33.81"^^xsd:float ;
+            rdf:value 33 ;
             sosa:isResultOf <urn:test:plot-description-enhanced-protocol-shapes:invalid:slope:site-visit> ;
-            tern:unit unit:DEG
+            tern:unit unit:Percent
         ] ;
-    sosa:hasSimpleResult "33.81"^^xsd:float ;
+    sosa:hasSimpleResult 33 ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/b036ba09-d061-4a1c-99a8-890efc462a2c> ;
     sosa:phenomenonTime <https://example.com/observation/slope/b91c54f2-9354-43ee-8412-09974fd2c23c/phenomenonTime> ;
     sosa:resultTime "2022-09-27T05:38:47.117000+00:00"^^xsd:dateTime ;
@@ -121,13 +121,13 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ;
     sosa:hasResult [
             a
-                tern:Float ,
+                tern:Integer ,
                 tern:Value ;
-            rdf:value "33.81"^^xsd:float ;
+            rdf:value 33 ;
             sosa:isResultOf <urn:test:plot-description-enhanced-protocol-shapes:invalid:slope:unit-of-measure> ;
             tern:unit <urn:fake:unit>
         ] ;
-    sosa:hasSimpleResult "33.81"^^xsd:float ;
+    sosa:hasSimpleResult 33 ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/b036ba09-d061-4a1c-99a8-890efc462a2c> ;
     sosa:phenomenonTime <https://example.com/observation/slope/b91c54f2-9354-43ee-8412-09974fd2c23c/phenomenonTime> ;
     sosa:resultTime "2022-09-27T05:38:47.117000+00:00"^^xsd:dateTime ;
@@ -146,13 +146,13 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ;
     sosa:hasResult [
             a
-                tern:Float ,
+                tern:Integer ,
                 tern:Value ;
-            rdf:value "33.81"^^xsd:float ;
+            rdf:value 33 ;
             sosa:isResultOf <urn:test:plot-description-enhanced-protocol-shapes:invalid:slope:used-procedure> ;
-            tern:unit unit:DEG
+            tern:unit unit:Percent
         ] ;
-    sosa:hasSimpleResult "33.81"^^xsd:float ;
+    sosa:hasSimpleResult 33 ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/b036ba09-d061-4a1c-99a8-890efc462a2c> ;
     sosa:phenomenonTime <https://example.com/observation/slope/b91c54f2-9354-43ee-8412-09974fd2c23c/phenomenonTime> ;
     sosa:resultTime "2022-09-27T05:38:47.117000+00:00"^^xsd:dateTime ;
@@ -171,13 +171,13 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ;
     sosa:hasResult [
             a
-                tern:Float ,
+                tern:Integer ,
                 tern:Value ;
-            rdf:value "-1.11"^^xsd:float ;
+            rdf:value -1 ;
             sosa:isResultOf <urn:test:plot-description-enhanced-protocol-shapes:invalid:slope:value-range> ;
-            tern:unit unit:DEG
+            tern:unit unit:Percent
         ] ;
-    sosa:hasSimpleResult "-1.11"^^xsd:float ;
+    sosa:hasSimpleResult -1 ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/b036ba09-d061-4a1c-99a8-890efc462a2c> ;
     sosa:phenomenonTime <https://example.com/observation/slope/b91c54f2-9354-43ee-8412-09974fd2c23c/phenomenonTime> ;
     sosa:resultTime "2022-09-27T05:38:47.117000+00:00"^^xsd:dateTime ;
@@ -188,7 +188,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <urn:test:plot-description-enhanced-protocol-shapes:invalid:slope:value-type>
     a tern:Observation ;
     void:inDataset <https://example.com/dataset/1> ;
-    rdfs:comment "Invalid result - the value of the result node must be `tern:Float`." ;
+    rdfs:comment "Invalid result - the value of the result node must be `tern:Integer`." ;
     sosa:hasFeatureOfInterest [
             a tern:FeatureOfInterest ;
             void:inDataset <https://example.com/dataset/1> ;
@@ -196,11 +196,11 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ;
     sosa:hasResult [
             a tern:Value ;
-            rdf:value "33.81"^^xsd:float ;
+            rdf:value 33 ;
             sosa:isResultOf <urn:test:plot-description-enhanced-protocol-shapes:invalid:slope:value-type> ;
-            tern:unit unit:DEG
+            tern:unit unit:Percent
         ] ;
-    sosa:hasSimpleResult "33.81"^^xsd:float ;
+    sosa:hasSimpleResult 33 ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/b036ba09-d061-4a1c-99a8-890efc462a2c> ;
     sosa:phenomenonTime <https://example.com/observation/slope/b91c54f2-9354-43ee-8412-09974fd2c23c/phenomenonTime> ;
     sosa:resultTime "2022-09-27T05:38:47.117000+00:00"^^xsd:dateTime ;

--- a/shapes/plot-description/plot-description-enhanced-protocol-shapes/slope/shapes.ttl
+++ b/shapes/plot-description/plot-description-enhanced-protocol-shapes/slope/shapes.ttl
@@ -167,9 +167,9 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     dcterms:source "Ecological Monitoring System - Australia Protocols" ;
     reg:status reg:statusSubmitted ;
     sh:datatype xsd:integer ;
-    sh:description "Value _MUST_ be between 0 and 90 inclusive." ;
-    sh:maxInclusive 90 ;
-    sh:message "The result _MUST_ have a value between 0 and 90 inclusively." ;
+    sh:description "Value _MUST_ be between 0 and 100 inclusive." ;
+    sh:maxInclusive 100 ;
+    sh:message "The result _MUST_ have a value between 0 and 100 inclusively." ;
     sh:minInclusive 0 ;
     sh:name "Value range" ;
     sh:path rdf:value ;

--- a/shapes/plot-description/plot-description-enhanced-protocol-shapes/slope/shapes.ttl
+++ b/shapes/plot-description/plot-description-enhanced-protocol-shapes/slope/shapes.ttl
@@ -106,9 +106,9 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         urnc:Requirement ;
     dcterms:source "Ecological Monitoring System - Australia Protocols" ;
     reg:status reg:statusSubmitted ;
-    sh:description "Result value's unit of measure _MUST_ have the value `unit:DEG`." ;
-    sh:hasValue unit:DEG ;
-    sh:message "The result _MUST_ have `unit:DEG` as the value for `tern:unit`." ;
+    sh:description "Result value's unit of measure _MUST_ have the value `unit:Percent`." ;
+    sh:hasValue unit:Percent ;
+    sh:message "The result _MUST_ have `unit:Percent` as the value for `tern:unit`." ;
     sh:name "Unit of measure" ;
     sh:path tern:unit ;
     sh:target [
@@ -166,7 +166,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         urnc:Requirement ;
     dcterms:source "Ecological Monitoring System - Australia Protocols" ;
     reg:status reg:statusSubmitted ;
-    sh:datatype xsd:float ;
+    sh:datatype xsd:integer ;
     sh:description "Value _MUST_ be between 0 and 90 inclusive." ;
     sh:maxInclusive 90 ;
     sh:message "The result _MUST_ have a value between 0 and 90 inclusively." ;
@@ -196,9 +196,9 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         urnc:Requirement ;
     dcterms:source "Ecological Monitoring System - Australia Protocols" ;
     reg:status reg:statusSubmitted ;
-    sh:class tern:Float ;
-    sh:description "The value of `sosa:hasResult` _MUST_ be a `tern:Float`." ;
-    sh:message "The result _MUST_ be an instance of `tern:Float`." ;
+    sh:class tern:Integer ;
+    sh:description "The value of `sosa:hasResult` _MUST_ be a `tern:Integer`." ;
+    sh:message "The result _MUST_ be an instance of `tern:Integer`." ;
     sh:name "Value type" ;
     sh:path sosa:hasResult ;
     sh:target [

--- a/shapes/plot-description/plot-description-enhanced-protocol-shapes/slope/valid.ttl
+++ b/shapes/plot-description/plot-description-enhanced-protocol-shapes/slope/valid.ttl
@@ -17,13 +17,13 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ;
     sosa:hasResult [
             a
-                tern:Float ,
+                tern:Integer ,
                 tern:Value ;
-            rdf:value "33.81"^^xsd:float ;
+            rdf:value 33 ;
             sosa:isResultOf <urn:test:plot-description-enhanced-protocol-shapes:valid:slope> ;
-            tern:unit unit:DEG
+            tern:unit unit:Percent
         ] ;
-    sosa:hasSimpleResult "33.81"^^xsd:float ;
+    sosa:hasSimpleResult 33 ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/b036ba09-d061-4a1c-99a8-890efc462a2c> ;
     sosa:phenomenonTime <https://example.com/observation/slope/b91c54f2-9354-43ee-8412-09974fd2c23c/phenomenonTime> ;
     sosa:resultTime "2022-09-27T05:38:47.117000+00:00"^^xsd:dateTime ;

--- a/shapes/plot-description/plot-description-standard-protocol-shapes/aspect/invalid.ttl
+++ b/shapes/plot-description/plot-description-standard-protocol-shapes/aspect/invalid.ttl
@@ -14,7 +14,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <urn:test:plot-description-standard-protocol-shapes:invalid:aspect:datatype>
     a tern:Observation ;
     void:inDataset <https://example.com/dataset/1> ;
-    rdfs:comment "Invalid result - the datatype of the value of the result node must be `xsd:float`." ;
+    rdfs:comment "Invalid result - the datatype of the value of the result node must be `xsd:integer`." ;
     sosa:hasFeatureOfInterest [
             a tern:FeatureOfInterest ;
             void:inDataset <https://example.com/dataset/1> ;
@@ -22,13 +22,13 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ;
     sosa:hasResult [
             a
-                tern:Float ,
+                tern:Integer ,
                 tern:Value ;
-            rdf:value 3 ;
+            rdf:value "33.81"^^xsd:float ;
             sosa:isResultOf <urn:test:plot-description-standard-protocol-shapes:invalid:aspect:datatype> ;
             tern:unit unit:DEG
         ] ;
-    sosa:hasSimpleResult 3 ;
+    sosa:hasSimpleResult "33.81"^^xsd:float ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/0e0423c6-0dc3-40aa-9776-410a94299256> ;
     sosa:phenomenonTime <https://example.com/observation/aspect/b91c54f2-9354-43ee-8412-09974fd2c23c/phenomenonTime> ;
     sosa:resultTime "2022-09-27T05:38:47.117000+00:00"^^xsd:dateTime ;
@@ -47,13 +47,13 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ;
     sosa:hasResult [
             a
-                tern:Float ,
+                tern:Integer ,
                 tern:Value ;
-            rdf:value "33.81"^^xsd:float ;
+            rdf:value 33 ;
             sosa:isResultOf <urn:test:plot-description-standard-protocol-shapes:invalid:aspect:feature-type> ;
             tern:unit unit:DEG
         ] ;
-    sosa:hasSimpleResult "33.81"^^xsd:float ;
+    sosa:hasSimpleResult 33 ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/0e0423c6-0dc3-40aa-9776-410a94299256> ;
     sosa:phenomenonTime <https://example.com/observation/aspect/b91c54f2-9354-43ee-8412-09974fd2c23c/phenomenonTime> ;
     sosa:resultTime "2022-09-27T05:38:47.117000+00:00"^^xsd:dateTime ;
@@ -72,13 +72,13 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ;
     sosa:hasResult [
             a
-                tern:Float ,
+                tern:Integer ,
                 tern:Value ;
-            rdf:value "33.81"^^xsd:float ;
+            rdf:value 33 ;
             sosa:isResultOf <urn:test:plot-description-standard-protocol-shapes:invalid:aspect:simple-result> ;
             tern:unit unit:DEG
         ] ;
-    sosa:hasSimpleResult "13.56"^^xsd:float ;
+    sosa:hasSimpleResult 13 ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/0e0423c6-0dc3-40aa-9776-410a94299256> ;
     sosa:phenomenonTime <https://example.com/observation/aspect/b91c54f2-9354-43ee-8412-09974fd2c23c/phenomenonTime> ;
     sosa:resultTime "2022-09-27T05:38:47.117000+00:00"^^xsd:dateTime ;
@@ -97,13 +97,13 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ;
     sosa:hasResult [
             a
-                tern:Float ,
+                tern:Integer ,
                 tern:Value ;
-            rdf:value "33.81"^^xsd:float ;
+            rdf:value 33 ;
             sosa:isResultOf <urn:test:plot-description-standard-protocol-shapes:invalid:aspect:site-visit> ;
             tern:unit unit:DEG
         ] ;
-    sosa:hasSimpleResult "33.81"^^xsd:float ;
+    sosa:hasSimpleResult 33 ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/0e0423c6-0dc3-40aa-9776-410a94299256> ;
     sosa:phenomenonTime <https://example.com/observation/aspect/b91c54f2-9354-43ee-8412-09974fd2c23c/phenomenonTime> ;
     sosa:resultTime "2022-09-27T05:38:47.117000+00:00"^^xsd:dateTime ;
@@ -121,13 +121,13 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ;
     sosa:hasResult [
             a
-                tern:Float ,
+                tern:Integer ,
                 tern:Value ;
-            rdf:value "33.81"^^xsd:float ;
+            rdf:value 33 ;
             sosa:isResultOf <urn:test:plot-description-standard-protocol-shapes:invalid:aspect:unit-of-measure> ;
             tern:unit <urn:fake:unit>
         ] ;
-    sosa:hasSimpleResult "33.81"^^xsd:float ;
+    sosa:hasSimpleResult 33 ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/0e0423c6-0dc3-40aa-9776-410a94299256> ;
     sosa:phenomenonTime <https://example.com/observation/aspect/b91c54f2-9354-43ee-8412-09974fd2c23c/phenomenonTime> ;
     sosa:resultTime "2022-09-27T05:38:47.117000+00:00"^^xsd:dateTime ;
@@ -146,13 +146,13 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ;
     sosa:hasResult [
             a
-                tern:Float ,
+                tern:Integer ,
                 tern:Value ;
-            rdf:value "33.81"^^xsd:float ;
+            rdf:value 33 ;
             sosa:isResultOf <urn:test:plot-description-standard-protocol-shapes:invalid:aspect:used-procedure> ;
             tern:unit unit:DEG
         ] ;
-    sosa:hasSimpleResult "33.81"^^xsd:float ;
+    sosa:hasSimpleResult 33 ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/0e0423c6-0dc3-40aa-9776-410a94299256> ;
     sosa:phenomenonTime <https://example.com/observation/aspect/b91c54f2-9354-43ee-8412-09974fd2c23c/phenomenonTime> ;
     sosa:resultTime "2022-09-27T05:38:47.117000+00:00"^^xsd:dateTime ;
@@ -171,13 +171,13 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ;
     sosa:hasResult [
             a
-                tern:Float ,
+                tern:Integer ,
                 tern:Value ;
-            rdf:value "-1.11"^^xsd:float ;
+            rdf:value -1 ;
             sosa:isResultOf <urn:test:plot-description-standard-protocol-shapes:invalid:aspect:value-range> ;
             tern:unit unit:DEG
         ] ;
-    sosa:hasSimpleResult "-1.11"^^xsd:float ;
+    sosa:hasSimpleResult -1;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/0e0423c6-0dc3-40aa-9776-410a94299256> ;
     sosa:phenomenonTime <https://example.com/observation/aspect/b91c54f2-9354-43ee-8412-09974fd2c23c/phenomenonTime> ;
     sosa:resultTime "2022-09-27T05:38:47.117000+00:00"^^xsd:dateTime ;
@@ -188,7 +188,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <urn:test:plot-description-standard-protocol-shapes:invalid:aspect:value-type>
     a tern:Observation ;
     void:inDataset <https://example.com/dataset/1> ;
-    rdfs:comment "Invalid result - the value of the result node must be `tern:Float`." ;
+    rdfs:comment "Invalid result - the value of the result node must be `tern:Integer`." ;
     sosa:hasFeatureOfInterest [
             a tern:FeatureOfInterest ;
             void:inDataset <https://example.com/dataset/1> ;
@@ -196,11 +196,11 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ;
     sosa:hasResult [
             a tern:Value ;
-            rdf:value "33.81"^^xsd:float ;
+            rdf:value 33 ;
             sosa:isResultOf <urn:test:plot-description-standard-protocol-shapes:invalid:aspect:value-type> ;
             tern:unit unit:DEG
         ] ;
-    sosa:hasSimpleResult "33.81"^^xsd:float ;
+    sosa:hasSimpleResult 33 ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/0e0423c6-0dc3-40aa-9776-410a94299256> ;
     sosa:phenomenonTime <https://example.com/observation/aspect/b91c54f2-9354-43ee-8412-09974fd2c23c/phenomenonTime> ;
     sosa:resultTime "2022-09-27T05:38:47.117000+00:00"^^xsd:dateTime ;

--- a/shapes/plot-description/plot-description-standard-protocol-shapes/aspect/shapes.ttl
+++ b/shapes/plot-description/plot-description-standard-protocol-shapes/aspect/shapes.ttl
@@ -166,7 +166,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         urnc:Requirement ;
     dcterms:source "Ecological Monitoring System - Australia Protocols" ;
     reg:status reg:statusSubmitted ;
-    sh:datatype xsd:float ;
+    sh:datatype xsd:integer ;
     sh:description "Value _MUST_ be between 0 exclusive and 360 inclusive." ;
     sh:maxInclusive 360 ;
     sh:message "The result _MUST_ have a value between 0 exclusive and 360 inclusive." ;
@@ -196,9 +196,9 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         urnc:Requirement ;
     dcterms:source "Ecological Monitoring System - Australia Protocols" ;
     reg:status reg:statusSubmitted ;
-    sh:class tern:Float ;
-    sh:description "The value of `sosa:hasResult` _MUST_ be a `tern:Float`." ;
-    sh:message "The result _MUST_ be an instance of `tern:Float`." ;
+    sh:class tern:Integer ;
+    sh:description "The value of `sosa:hasResult` _MUST_ be a `tern:Integer`." ;
+    sh:message "The result _MUST_ be an instance of `tern:Integer`." ;
     sh:name "Value type" ;
     sh:path sosa:hasResult ;
     sh:target [

--- a/shapes/plot-description/plot-description-standard-protocol-shapes/aspect/valid.ttl
+++ b/shapes/plot-description/plot-description-standard-protocol-shapes/aspect/valid.ttl
@@ -17,13 +17,13 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ;
     sosa:hasResult [
             a
-                tern:Float ,
+                tern:Integer ,
                 tern:Value ;
-            rdf:value "33.81"^^xsd:float ;
+            rdf:value 33 ;
             sosa:isResultOf <urn:test:plot-description-standard-protocol-shapes:valid:aspect> ;
             tern:unit unit:DEG
         ] ;
-    sosa:hasSimpleResult "33.81"^^xsd:float ;
+    sosa:hasSimpleResult 33 ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/0e0423c6-0dc3-40aa-9776-410a94299256> ;
     sosa:phenomenonTime <https://example.com/observation/aspect/b91c54f2-9354-43ee-8412-09974fd2c23c/phenomenonTime> ;
     sosa:resultTime "2022-09-27T05:38:47.117000+00:00"^^xsd:dateTime ;

--- a/shapes/plot-description/plot-description-standard-protocol-shapes/homogeneity-measure/invalid.ttl
+++ b/shapes/plot-description/plot-description-standard-protocol-shapes/homogeneity-measure/invalid.ttl
@@ -14,7 +14,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <urn:test:plot-description-standard-protocol-shapes:invalid:homogeneity-measure:datatype>
     a tern:Observation ;
     void:inDataset <https://example.com/dataset/1> ;
-    rdfs:comment "Invalid result - the datatype of the value of the result node must be `xsd:float`." ;
+    rdfs:comment "Invalid result - the datatype of the value of the result node must be `xsd:integer`." ;
     sosa:hasFeatureOfInterest [
             a tern:FeatureOfInterest ;
             void:inDataset <https://example.com/dataset/1> ;
@@ -22,13 +22,13 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ;
     sosa:hasResult [
             a
-                tern:Float ,
+                tern:Integer ,
                 tern:Value ;
-            rdf:value 3 ;
+            rdf:value "33.81"^^xsd:float ;
             sosa:isResultOf <urn:test:plot-description-standard-protocol-shapes:invalid:homogeneity-measure:datatype> ;
             tern:unit unit:M
         ] ;
-    sosa:hasSimpleResult 3 ;
+    sosa:hasSimpleResult "33.81"^^xsd:float ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/325d5ff2-8c81-484a-a422-c13ff29666a9> ;
     sosa:phenomenonTime <https://example.com/observation/homogeneity-measure/b91c54f2-9354-43ee-8412-09974fd2c23c/phenomenonTime> ;
     sosa:resultTime "2022-09-27T05:38:47.117000+00:00"^^xsd:dateTime ;
@@ -47,13 +47,13 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ;
     sosa:hasResult [
             a
-                tern:Float ,
+                tern:Integer ,
                 tern:Value ;
-            rdf:value "33.81"^^xsd:float ;
+            rdf:value 33 ;
             sosa:isResultOf <urn:test:plot-description-standard-protocol-shapes:invalid:homogeneity-measure:feature-type> ;
             tern:unit unit:M
         ] ;
-    sosa:hasSimpleResult "33.81"^^xsd:float ;
+    sosa:hasSimpleResult 33 ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/325d5ff2-8c81-484a-a422-c13ff29666a9> ;
     sosa:phenomenonTime <https://example.com/observation/homogeneity-measure/b91c54f2-9354-43ee-8412-09974fd2c23c/phenomenonTime> ;
     sosa:resultTime "2022-09-27T05:38:47.117000+00:00"^^xsd:dateTime ;
@@ -72,13 +72,13 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ;
     sosa:hasResult [
             a
-                tern:Float ,
+                tern:Integer ,
                 tern:Value ;
-            rdf:value "33.81"^^xsd:float ;
+            rdf:value 33 ;
             sosa:isResultOf <urn:test:plot-description-standard-protocol-shapes:invalid:homogeneity-measure:simple-result> ;
             tern:unit unit:M
         ] ;
-    sosa:hasSimpleResult "13.56"^^xsd:float ;
+    sosa:hasSimpleResult 13 ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/325d5ff2-8c81-484a-a422-c13ff29666a9> ;
     sosa:phenomenonTime <https://example.com/observation/homogeneity-measure/b91c54f2-9354-43ee-8412-09974fd2c23c/phenomenonTime> ;
     sosa:resultTime "2022-09-27T05:38:47.117000+00:00"^^xsd:dateTime ;
@@ -97,13 +97,13 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ;
     sosa:hasResult [
             a
-                tern:Float ,
+                tern:Integer ,
                 tern:Value ;
-            rdf:value "33.81"^^xsd:float ;
+            rdf:value 33 ;
             sosa:isResultOf <urn:test:plot-description-standard-protocol-shapes:invalid:homogeneity-measure:site-visit> ;
             tern:unit unit:M
         ] ;
-    sosa:hasSimpleResult "33.81"^^xsd:float ;
+    sosa:hasSimpleResult 33 ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/325d5ff2-8c81-484a-a422-c13ff29666a9> ;
     sosa:phenomenonTime <https://example.com/observation/homogeneity-measure/b91c54f2-9354-43ee-8412-09974fd2c23c/phenomenonTime> ;
     sosa:resultTime "2022-09-27T05:38:47.117000+00:00"^^xsd:dateTime ;
@@ -121,13 +121,13 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ;
     sosa:hasResult [
             a
-                tern:Float ,
+                tern:Integer ,
                 tern:Value ;
-            rdf:value "33.81"^^xsd:float ;
+            rdf:value 33 ;
             sosa:isResultOf <urn:test:plot-description-standard-protocol-shapes:invalid:homogeneity-measure:unit-of-measure> ;
             tern:unit <urn:fake:unit>
         ] ;
-    sosa:hasSimpleResult "33.81"^^xsd:float ;
+    sosa:hasSimpleResult 33 ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/325d5ff2-8c81-484a-a422-c13ff29666a9> ;
     sosa:phenomenonTime <https://example.com/observation/homogeneity-measure/b91c54f2-9354-43ee-8412-09974fd2c23c/phenomenonTime> ;
     sosa:resultTime "2022-09-27T05:38:47.117000+00:00"^^xsd:dateTime ;
@@ -146,13 +146,13 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ;
     sosa:hasResult [
             a
-                tern:Float ,
+                tern:Integer ,
                 tern:Value ;
-            rdf:value "33.81"^^xsd:float ;
+            rdf:value 33 ;
             sosa:isResultOf <urn:test:plot-description-standard-protocol-shapes:invalid:homogeneity-measure:used-procedure> ;
             tern:unit unit:M
         ] ;
-    sosa:hasSimpleResult "33.81"^^xsd:float ;
+    sosa:hasSimpleResult 33 ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/325d5ff2-8c81-484a-a422-c13ff29666a9> ;
     sosa:phenomenonTime <https://example.com/observation/homogeneity-measure/b91c54f2-9354-43ee-8412-09974fd2c23c/phenomenonTime> ;
     sosa:resultTime "2022-09-27T05:38:47.117000+00:00"^^xsd:dateTime ;
@@ -171,13 +171,13 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ;
     sosa:hasResult [
             a
-                tern:Float ,
+                tern:Integer ,
                 tern:Value ;
-            rdf:value "-1.11"^^xsd:float ;
+            rdf:value -1 ;
             sosa:isResultOf <urn:test:plot-description-standard-protocol-shapes:invalid:homogeneity-measure:value-range> ;
             tern:unit unit:M
         ] ;
-    sosa:hasSimpleResult "-1.11"^^xsd:float ;
+    sosa:hasSimpleResult -1 ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/325d5ff2-8c81-484a-a422-c13ff29666a9> ;
     sosa:phenomenonTime <https://example.com/observation/homogeneity-measure/b91c54f2-9354-43ee-8412-09974fd2c23c/phenomenonTime> ;
     sosa:resultTime "2022-09-27T05:38:47.117000+00:00"^^xsd:dateTime ;
@@ -188,7 +188,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <urn:test:plot-description-standard-protocol-shapes:invalid:homogeneity-measure:value-type>
     a tern:Observation ;
     void:inDataset <https://example.com/dataset/1> ;
-    rdfs:comment "Invalid result - the value of the result node must be `tern:Float`." ;
+    rdfs:comment "Invalid result - the value of the result node must be `tern:Integer`." ;
     sosa:hasFeatureOfInterest [
             a tern:FeatureOfInterest ;
             void:inDataset <https://example.com/dataset/1> ;
@@ -196,11 +196,11 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ;
     sosa:hasResult [
             a tern:Value ;
-            rdf:value "33.81"^^xsd:float ;
+            rdf:value 33 ;
             sosa:isResultOf <urn:test:plot-description-standard-protocol-shapes:invalid:homogeneity-measure:value-type> ;
             tern:unit unit:M
         ] ;
-    sosa:hasSimpleResult "33.81"^^xsd:float ;
+    sosa:hasSimpleResult 33 ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/325d5ff2-8c81-484a-a422-c13ff29666a9> ;
     sosa:phenomenonTime <https://example.com/observation/homogeneity-measure/b91c54f2-9354-43ee-8412-09974fd2c23c/phenomenonTime> ;
     sosa:resultTime "2022-09-27T05:38:47.117000+00:00"^^xsd:dateTime ;

--- a/shapes/plot-description/plot-description-standard-protocol-shapes/homogeneity-measure/shapes.ttl
+++ b/shapes/plot-description/plot-description-standard-protocol-shapes/homogeneity-measure/shapes.ttl
@@ -166,7 +166,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         urnc:Requirement ;
     dcterms:source "Ecological Monitoring System - Australia Protocols" ;
     reg:status reg:statusSubmitted ;
-    sh:datatype xsd:float ;
+    sh:datatype xsd:integer ;
     sh:description "Value _MUST_ not be negative." ;
     sh:message "The result _MUST_ not be negative." ;
     sh:minInclusive 0 ;
@@ -195,9 +195,9 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         urnc:Requirement ;
     dcterms:source "Ecological Monitoring System - Australia Protocols" ;
     reg:status reg:statusSubmitted ;
-    sh:class tern:Float ;
-    sh:description "The value of `sosa:hasResult` _MUST_ be a `tern:Float`." ;
-    sh:message "The result _MUST_ be an instance of `tern:Float`." ;
+    sh:class tern:Integer ;
+    sh:description "The value of `sosa:hasResult` _MUST_ be a `tern:Integer`." ;
+    sh:message "The result _MUST_ be an instance of `tern:Integer`." ;
     sh:name "Value type" ;
     sh:path sosa:hasResult ;
     sh:target [

--- a/shapes/plot-description/plot-description-standard-protocol-shapes/homogeneity-measure/valid.ttl
+++ b/shapes/plot-description/plot-description-standard-protocol-shapes/homogeneity-measure/valid.ttl
@@ -17,13 +17,13 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ;
     sosa:hasResult [
             a
-                tern:Float ,
+                tern:Integer ,
                 tern:Value ;
-            rdf:value "33.81"^^xsd:float ;
+            rdf:value 33 ;
             sosa:isResultOf <urn:test:plot-description-standard-protocol-shapes:valid:homogeneity-measure> ;
             tern:unit unit:M
         ] ;
-    sosa:hasSimpleResult "33.81"^^xsd:float ;
+    sosa:hasSimpleResult 33 ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/325d5ff2-8c81-484a-a422-c13ff29666a9> ;
     sosa:phenomenonTime <https://example.com/observation/homogeneity-measure/b91c54f2-9354-43ee-8412-09974fd2c23c/phenomenonTime> ;
     sosa:resultTime "2022-09-27T05:38:47.117000+00:00"^^xsd:dateTime ;

--- a/shapes/vegetation-mapping-protocol-shapes/homogeneity-measure/invalid.ttl
+++ b/shapes/vegetation-mapping-protocol-shapes/homogeneity-measure/invalid.ttl
@@ -14,7 +14,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <urn:test:vegetation-mapping-protocol-shapes:invalid:homogeneity-measure:datatype>
     a tern:Observation ;
     void:inDataset <https://example.com/dataset/1> ;
-    rdfs:comment "Invalid result - the datatype of the value of the result node must be `xsd:float`." ;
+    rdfs:comment "Invalid result - the datatype of the value of the result node must be `xsd:integer`." ;
     sosa:hasFeatureOfInterest [
             a tern:FeatureOfInterest ;
             void:inDataset <https://example.com/dataset/1> ;
@@ -22,13 +22,13 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ;
     sosa:hasResult [
             a
-                tern:Float ,
+                tern:Integer ,
                 tern:Value ;
-            rdf:value 3 ;
+            rdf:value "33.81"^^xsd:float ;
             sosa:isResultOf <urn:test:vegetation-mapping-protocol-shapes:invalid:homogeneity-measure:datatype> ;
             tern:unit unit:M
         ] ;
-    sosa:hasSimpleResult 3 ;
+    sosa:hasSimpleResult "33.81"^^xsd:float ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/325d5ff2-8c81-484a-a422-c13ff29666a9> ;
     sosa:phenomenonTime <https://example.com/observation/homogeneity-measure/b91c54f2-9354-43ee-8412-09974fd2c23c/phenomenonTime> ;
     sosa:resultTime "2022-09-27T05:38:47.117000+00:00"^^xsd:dateTime ;
@@ -46,13 +46,13 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ;
     sosa:hasResult [
             a
-                tern:Float ,
+                tern:Integer ,
                 tern:Value ;
-            rdf:value "33.81"^^xsd:float ;
+            rdf:value 33 ;
             sosa:isResultOf <urn:test:vegetation-mapping-protocol-shapes:invalid:homogeneity-measure:feature-type> ;
             tern:unit unit:M
         ] ;
-    sosa:hasSimpleResult "33.81"^^xsd:float ;
+    sosa:hasSimpleResult 33 ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/325d5ff2-8c81-484a-a422-c13ff29666a9> ;
     sosa:phenomenonTime <https://example.com/observation/homogeneity-measure/b91c54f2-9354-43ee-8412-09974fd2c23c/phenomenonTime> ;
     sosa:resultTime "2022-09-27T05:38:47.117000+00:00"^^xsd:dateTime ;
@@ -70,13 +70,13 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ;
     sosa:hasResult [
             a
-                tern:Float ,
+                tern:Integer ,
                 tern:Value ;
-            rdf:value "33.81"^^xsd:float ;
+            rdf:value 33 ;
             sosa:isResultOf <urn:test:vegetation-mapping-protocol-shapes:invalid:homogeneity-measure:simple-result> ;
             tern:unit unit:M
         ] ;
-    sosa:hasSimpleResult "13.56"^^xsd:float ;
+    sosa:hasSimpleResult 13 ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/325d5ff2-8c81-484a-a422-c13ff29666a9> ;
     sosa:phenomenonTime <https://example.com/observation/homogeneity-measure/b91c54f2-9354-43ee-8412-09974fd2c23c/phenomenonTime> ;
     sosa:resultTime "2022-09-27T05:38:47.117000+00:00"^^xsd:dateTime ;
@@ -94,13 +94,13 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ;
     sosa:hasResult [
             a
-                tern:Float ,
+                tern:Integer ,
                 tern:Value ;
-            rdf:value "33.81"^^xsd:float ;
+            rdf:value 33 ;
             sosa:isResultOf <urn:test:vegetation-mapping-protocol-shapes:invalid:homogeneity-measure:unit-of-measure> ;
             tern:unit <urn:fake:unit>
         ] ;
-    sosa:hasSimpleResult "33.81"^^xsd:float ;
+    sosa:hasSimpleResult 33 ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/325d5ff2-8c81-484a-a422-c13ff29666a9> ;
     sosa:phenomenonTime <https://example.com/observation/homogeneity-measure/b91c54f2-9354-43ee-8412-09974fd2c23c/phenomenonTime> ;
     sosa:resultTime "2022-09-27T05:38:47.117000+00:00"^^xsd:dateTime ;
@@ -118,13 +118,13 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ;
     sosa:hasResult [
             a
-                tern:Float ,
+                tern:Integer ,
                 tern:Value ;
-            rdf:value "33.81"^^xsd:float ;
+            rdf:value 33 ;
             sosa:isResultOf <urn:test:vegetation-mapping-protocol-shapes:invalid:homogeneity-measure:used-procedure> ;
             tern:unit unit:M
         ] ;
-    sosa:hasSimpleResult "33.81"^^xsd:float ;
+    sosa:hasSimpleResult 33 ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/325d5ff2-8c81-484a-a422-c13ff29666a9> ;
     sosa:phenomenonTime <https://example.com/observation/homogeneity-measure/b91c54f2-9354-43ee-8412-09974fd2c23c/phenomenonTime> ;
     sosa:resultTime "2022-09-27T05:38:47.117000+00:00"^^xsd:dateTime ;
@@ -142,13 +142,13 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ;
     sosa:hasResult [
             a
-                tern:Float ,
+                tern:Integer ,
                 tern:Value ;
-            rdf:value "-1.11"^^xsd:float ;
+            rdf:value -1 ;
             sosa:isResultOf <urn:test:vegetation-mapping-protocol-shapes:invalid:homogeneity-measure:value-range> ;
             tern:unit unit:M
         ] ;
-    sosa:hasSimpleResult "-1.11"^^xsd:float ;
+    sosa:hasSimpleResult -1 ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/325d5ff2-8c81-484a-a422-c13ff29666a9> ;
     sosa:phenomenonTime <https://example.com/observation/homogeneity-measure/b91c54f2-9354-43ee-8412-09974fd2c23c/phenomenonTime> ;
     sosa:resultTime "2022-09-27T05:38:47.117000+00:00"^^xsd:dateTime ;
@@ -158,7 +158,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <urn:test:vegetation-mapping-protocol-shapes:invalid:homogeneity-measure:value-type>
     a tern:Observation ;
     void:inDataset <https://example.com/dataset/1> ;
-    rdfs:comment "Invalid result - the value of the result node must be `tern:Float`." ;
+    rdfs:comment "Invalid result - the value of the result node must be `tern:Integer`." ;
     sosa:hasFeatureOfInterest [
             a tern:FeatureOfInterest ;
             void:inDataset <https://example.com/dataset/1> ;
@@ -166,11 +166,11 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ;
     sosa:hasResult [
             a tern:Value ;
-            rdf:value "33.81"^^xsd:float ;
+            rdf:value 33 ;
             sosa:isResultOf <urn:test:vegetation-mapping-protocol-shapes:invalid:homogeneity-measure:value-type> ;
             tern:unit unit:M
         ] ;
-    sosa:hasSimpleResult "33.81"^^xsd:float ;
+    sosa:hasSimpleResult 33 ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/325d5ff2-8c81-484a-a422-c13ff29666a9> ;
     sosa:phenomenonTime <https://example.com/observation/homogeneity-measure/b91c54f2-9354-43ee-8412-09974fd2c23c/phenomenonTime> ;
     sosa:resultTime "2022-09-27T05:38:47.117000+00:00"^^xsd:dateTime ;

--- a/shapes/vegetation-mapping-protocol-shapes/homogeneity-measure/shapes.ttl
+++ b/shapes/vegetation-mapping-protocol-shapes/homogeneity-measure/shapes.ttl
@@ -136,7 +136,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         urnc:Requirement ;
     dcterms:source "Ecological Monitoring System - Australia Protocols" ;
     reg:status reg:statusSubmitted ;
-    sh:datatype xsd:float ;
+    sh:datatype xsd:integer ;
     sh:description "Value _MUST_ be between 0 exclusive and 1000 inclusive." ;
     sh:maxInclusive 1000 ;
     sh:message "The result _MUST_ have a value between 0 exclusively and 1000 inclusively." ;
@@ -166,9 +166,9 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         urnc:Requirement ;
     dcterms:source "Ecological Monitoring System - Australia Protocols" ;
     reg:status reg:statusSubmitted ;
-    sh:class tern:Float ;
-    sh:description "The value of `sosa:hasResult` _MUST_ be a `tern:Float`." ;
-    sh:message "The result _MUST_ be an instance of `tern:Float`." ;
+    sh:class tern:Integer ;
+    sh:description "The value of `sosa:hasResult` _MUST_ be a `tern:Integer`." ;
+    sh:message "The result _MUST_ be an instance of `tern:Integer`." ;
     sh:name "Value type" ;
     sh:path sosa:hasResult ;
     sh:target [

--- a/shapes/vegetation-mapping-protocol-shapes/homogeneity-measure/valid.ttl
+++ b/shapes/vegetation-mapping-protocol-shapes/homogeneity-measure/valid.ttl
@@ -22,13 +22,13 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         ] ;
     sosa:hasResult [
             a
-                tern:Float ,
+                tern:Integer ,
                 tern:Value ;
-            rdf:value "33.81"^^xsd:float ;
+            rdf:value 33 ;
             sosa:isResultOf <urn:test:vegetation-mapping-protocol-shapes:valid:homogeneity-measure> ;
             tern:unit unit:M
         ] ;
-    sosa:hasSimpleResult "33.81"^^xsd:float ;
+    sosa:hasSimpleResult 33 ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/325d5ff2-8c81-484a-a422-c13ff29666a9> ;
     sosa:phenomenonTime <https://example.com/observation/homogeneity-measure/b91c54f2-9354-43ee-8412-09974fd2c23c/phenomenonTime> ;
     sosa:resultTime "2022-09-27T05:38:47.117000+00:00"^^xsd:dateTime ;


### PR DESCRIPTION
This PR updated SHACL shapes for:

1. **opportunistic-observations-protocol-shapes**: field-species-name and taxa-type: allow animal-occurrence FoI
2. **vegetation-mapping**: homogeneity-measure Float to Integer
3. **plot-description-enhanced**: aspect, slope and homogeneity-measure Float to Integer
4. **plot-description-standard**: aspect and homogeneity-measure Float to Integer