### PR TITLE
Removed deprecated ACLUM vocabulary IRI validations & Made shapes copies in `plant tissue vouchering`

### DIFF
--- a/shapes/plant-tissue-vouchering/plant-tissue-vouchering-enhanced-protocol-shapes/shapes.ttl
+++ b/shapes/plant-tissue-vouchering/plant-tissue-vouchering-enhanced-protocol-shapes/shapes.ttl
@@ -1,0 +1,226 @@
+PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX reg: <http://purl.org/linked-data/registry#>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+PREFIX sosa: <http://www.w3.org/ns/sosa/>
+PREFIX tern: <https://w3id.org/tern/ontologies/tern/>
+PREFIX unit: <http://qudt.org/vocab/unit/>
+PREFIX urnc: <urn:class:>
+PREFIX urnp: <urn:property:>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+<urn:shapes:plant-tissue-vouchering-enhanced-protocol-shapes:shortest-distance-between-replicates:feature-type>
+    a
+        sh:PropertyShape ,
+        urnc:Requirement ;
+    dcterms:source "Ecological Monitoring System - Australia Protocols" ;
+    reg:status reg:statusSubmitted ;
+    sh:description "TERN's ecologists have determined the feature type is _plant population_, defined by the link:https://www.publish.csiro.au/book/5230/[Australian Soil and Land Survey Field Handbook]." ;
+    sh:hasValue <http://linked.data.gov.au/def/tern-cv/ae71c3f6-d430-400f-a1d4-97a333b4ee02> ;
+    sh:message "The value of `tern:featureType` _MUST_ be link: http://linked.data.gov.au/def/tern-cv/ae71c3f6-d430-400f-a1d4-97a333b4ee02[`plant population`]." ;
+    sh:name "Feature type" ;
+    sh:path tern:featureType ;
+    sh:target [
+            a sh:SPARQLTarget ;
+            sh:select """
+    PREFIX tern: <https://w3id.org/tern/ontologies/tern/>
+    PREFIX unit: <http://qudt.org/vocab/unit/>
+    PREFIX sosa: <http://www.w3.org/ns/sosa/>
+    select ?this  {
+        values ?property_uri {<https://linked.data.gov.au/def/nrm/3b2aa21d-c60f-45c5-9447-ff8a799a513e>}
+        ?observation a tern:Observation ;
+            sosa:observedProperty ?property_uri ;
+            sosa:hasFeatureOfInterest ?this .
+    }
+    """
+        ] ;
+    urnp:examples _:n3742544b36f246f48a79c1f3a4b0a2b8b2 ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plant-tissue-vouchering/plant-tissue-vouchering-enhanced-protocol-shapes/shortest-distance-between-replicates/shapes.ttl"^^xsd:anyURI ;
+.
+
+<urn:shapes:plant-tissue-vouchering-enhanced-protocol-shapes:shortest-distance-between-replicates:simple-result>
+    a
+        sh:NodeShape ,
+        urnc:Requirement ;
+    dcterms:source "Ecological Monitoring System - Australia Protocols" ;
+    reg:status reg:statusSubmitted ;
+    sh:description "Value of `sosa:hasSimpleResult` _MUST_ be the same as the value in `sosa:hasResult`." ;
+    sh:message "The observation's `sosa:hasSimpleResult` _MUST_ have a value that is the same as the value in the value node of `sosa:hasResult`." ;
+    sh:name "Simple result" ;
+    sh:sparql [
+            sh:select """
+    PREFIX tern: <https://w3id.org/tern/ontologies/tern/>
+    PREFIX unit: <http://qudt.org/vocab/unit/>
+    PREFIX sosa: <http://www.w3.org/ns/sosa/>
+    PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+    select $this {
+        $this a tern:Observation ;
+            sosa:observedProperty 
+    <https://linked.data.gov.au/def/nrm/3b2aa21d-c60f-45c5-9447-ff8a799a513e>
+     ;
+            sosa:hasSimpleResult ?simple ;
+            sosa:hasResult ?result .
+        ?result rdf:value ?value .
+        filter (?simple != ?value)
+    }
+    """
+        ] ;
+    sh:targetClass tern:Observation ;
+    urnp:examples _:n3742544b36f246f48a79c1f3a4b0a2b8b2 ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plant-tissue-vouchering/plant-tissue-vouchering-enhanced-protocol-shapes/shortest-distance-between-replicates/shapes.ttl"^^xsd:anyURI ;
+.
+
+<urn:shapes:plant-tissue-vouchering-enhanced-protocol-shapes:shortest-distance-between-replicates:site-visit>
+    a
+        sh:PropertyShape ,
+        urnc:Requirement ;
+    dcterms:source "Ecological Monitoring System - Australia Protocols" ;
+    reg:status reg:statusSubmitted ;
+    sh:description "Observations following the Plant Tissue Vouchering - Enhanced Protocol are made in the context of a site visit." ;
+    sh:maxCount 1 ;
+    sh:message "Observations _MUST_ have a value for `tern:hasSiteVisit`." ;
+    sh:minCount 1 ;
+    sh:name "Site visit" ;
+    sh:path tern:hasSiteVisit ;
+    sh:target [
+            a sh:SPARQLTarget ;
+            sh:select """
+    PREFIX tern: <https://w3id.org/tern/ontologies/tern/>
+    PREFIX unit: <http://qudt.org/vocab/unit/>
+    PREFIX sosa: <http://www.w3.org/ns/sosa/>
+    PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+    select ?this {
+        values ?property_uri {<https://linked.data.gov.au/def/nrm/3b2aa21d-c60f-45c5-9447-ff8a799a513e>}
+        ?this a tern:Observation ;
+            sosa:observedProperty ?property_uri .
+    }
+    """
+        ] ;
+    urnp:examples _:n3742544b36f246f48a79c1f3a4b0a2b8b2 ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plant-tissue-vouchering/plant-tissue-vouchering-enhanced-protocol-shapes/shortest-distance-between-replicates/shapes.ttl"^^xsd:anyURI ;
+.
+
+<urn:shapes:plant-tissue-vouchering-enhanced-protocol-shapes:shortest-distance-between-replicates:unit-of-measure>
+    a
+        sh:PropertyShape ,
+        urnc:Requirement ;
+    dcterms:source "Ecological Monitoring System - Australia Protocols" ;
+    reg:status reg:statusSubmitted ;
+    sh:description "Result value's unit of measure _MUST_ have the value `unit:M`." ;
+    sh:hasValue unit:M ;
+    sh:message "The result _MUST_ have `unit:M` as the value for `tern:unit`." ;
+    sh:name "Unit of measure" ;
+    sh:path tern:unit ;
+    sh:target [
+            a sh:SPARQLTarget ;
+            sh:select """
+        PREFIX tern: <https://w3id.org/tern/ontologies/tern/>
+        PREFIX sosa: <http://www.w3.org/ns/sosa/>
+        PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+        select ?this  {
+            ?observation a tern:Observation ;
+                sosa:observedProperty 
+        <https://linked.data.gov.au/def/nrm/3b2aa21d-c60f-45c5-9447-ff8a799a513e> ;
+                sosa:hasResult ?this .
+        }"""
+        ] ;
+    urnp:examples _:n3742544b36f246f48a79c1f3a4b0a2b8b2 ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plant-tissue-vouchering/plant-tissue-vouchering-enhanced-protocol-shapes/shortest-distance-between-replicates/shapes.ttl"^^xsd:anyURI ;
+.
+
+<urn:shapes:plant-tissue-vouchering-enhanced-protocol-shapes:shortest-distance-between-replicates:used-procedure>
+    a
+        sh:PropertyShape ,
+        urnc:Requirement ;
+    dcterms:source "Ecological Monitoring System - Australia Protocols" ;
+    reg:status reg:statusSubmitted ;
+    sh:description """IRI of method in procedure _MUST_ have the value `<https://linked.data.gov.au/def/nrm/eea8280c-6ec7-48c9-9b9e-2418731ff005>`.
+
+    `<https://linked.data.gov.au/def/nrm/eea8280c-6ec7-48c9-9b9e-2418731ff005>` is the IRI for "Plant Tissue Vouchering - Enhanced Protocol".""" ;
+    sh:hasValue <https://linked.data.gov.au/def/nrm/eea8280c-6ec7-48c9-9b9e-2418731ff005> ;
+    sh:message "The procedure's `tern:methodType` _MUST_ have the value `https://linked.data.gov.au/def/nrm/eea8280c-6ec7-48c9-9b9e-2418731ff005`." ;
+    sh:name "Method type of used procedure" ;
+    sh:path tern:methodType ;
+    sh:target [
+            a sh:SPARQLTarget ;
+            sh:select """
+    PREFIX tern: <https://w3id.org/tern/ontologies/tern/>
+    PREFIX unit: <http://qudt.org/vocab/unit/>
+    PREFIX sosa: <http://www.w3.org/ns/sosa/>
+    PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+    select ?this {
+        values ?property_uri {<https://linked.data.gov.au/def/nrm/3b2aa21d-c60f-45c5-9447-ff8a799a513e>}
+        ?observation a tern:Observation ;
+            sosa:observedProperty ?property_uri ;
+            sosa:usedProcedure ?this .
+    }
+    """
+        ] ;
+    urnp:examples _:n3742544b36f246f48a79c1f3a4b0a2b8b2 ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plant-tissue-vouchering/plant-tissue-vouchering-enhanced-protocol-shapes/shortest-distance-between-replicates/shapes.ttl"^^xsd:anyURI ;
+.
+
+<urn:shapes:plant-tissue-vouchering-enhanced-protocol-shapes:shortest-distance-between-replicates:value-range>
+    a
+        sh:PropertyShape ,
+        urnc:Requirement ;
+    dcterms:source "Ecological Monitoring System - Australia Protocols" ;
+    reg:status reg:statusSubmitted ;
+    sh:datatype xsd:float ;
+    sh:description "Value _MUST_ be between 0 exclusive and 100 inclusive." ;
+    sh:maxInclusive 100 ;
+    sh:message "The result _MUST_ have a value between 0 exclusively and 100 inclusively." ;
+    sh:minExclusive 0 ;
+    sh:name "Value range" ;
+    sh:path rdf:value ;
+    sh:target [
+            a sh:SPARQLTarget ;
+            sh:select """
+        PREFIX tern: <https://w3id.org/tern/ontologies/tern/>
+        PREFIX sosa: <http://www.w3.org/ns/sosa/>
+        PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+        select ?this  {
+            ?observation a tern:Observation ;
+                sosa:observedProperty 
+        <https://linked.data.gov.au/def/nrm/3b2aa21d-c60f-45c5-9447-ff8a799a513e> ;
+                sosa:hasResult ?this .
+        }"""
+        ] ;
+    urnp:examples _:n3742544b36f246f48a79c1f3a4b0a2b8b2 ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plant-tissue-vouchering/plant-tissue-vouchering-enhanced-protocol-shapes/shortest-distance-between-replicates/shapes.ttl"^^xsd:anyURI ;
+.
+
+<urn:shapes:plant-tissue-vouchering-enhanced-protocol-shapes:shortest-distance-between-replicates:value-type>
+    a
+        sh:PropertyShape ,
+        urnc:Requirement ;
+    dcterms:source "Ecological Monitoring System - Australia Protocols" ;
+    reg:status reg:statusSubmitted ;
+    sh:class tern:Float ;
+    sh:description "The value of `sosa:hasResult` _MUST_ be a `tern:Float`." ;
+    sh:message "The result _MUST_ be an instance of `tern:Float`." ;
+    sh:name "Value type" ;
+    sh:path sosa:hasResult ;
+    sh:target [
+            a sh:SPARQLTarget ;
+            sh:select """
+    PREFIX tern: <https://w3id.org/tern/ontologies/tern/>
+    PREFIX unit: <http://qudt.org/vocab/unit/>
+    PREFIX sosa: <http://www.w3.org/ns/sosa/>
+    PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+    select ?this {
+        values ?property_uri {<https://linked.data.gov.au/def/nrm/3b2aa21d-c60f-45c5-9447-ff8a799a513e>}
+        ?this a tern:Observation ;
+            sosa:observedProperty ?property_uri .
+    }
+    """
+        ] ;
+    urnp:examples _:n3742544b36f246f48a79c1f3a4b0a2b8b2 ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plant-tissue-vouchering/plant-tissue-vouchering-enhanced-protocol-shapes/shortest-distance-between-replicates/shapes.ttl"^^xsd:anyURI ;
+.
+
+_:n3742544b36f246f48a79c1f3a4b0a2b8b2
+    urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plant-tissue-vouchering/plant-tissue-vouchering-enhanced-protocol-shapes/shortest-distance-between-replicates/invalid.ttl"^^xsd:anyURI ;
+    urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plant-tissue-vouchering/plant-tissue-vouchering-enhanced-protocol-shapes/shortest-distance-between-replicates/valid.ttl"^^xsd:anyURI ;
+.
+

--- a/shapes/plant-tissue-vouchering/plant-tissue-vouchering-standard-protocol-shapes/shapes.ttl
+++ b/shapes/plant-tissue-vouchering/plant-tissue-vouchering-standard-protocol-shapes/shapes.ttl
@@ -1,0 +1,226 @@
+PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX reg: <http://purl.org/linked-data/registry#>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+PREFIX sosa: <http://www.w3.org/ns/sosa/>
+PREFIX tern: <https://w3id.org/tern/ontologies/tern/>
+PREFIX unit: <http://qudt.org/vocab/unit/>
+PREFIX urnc: <urn:class:>
+PREFIX urnp: <urn:property:>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+<urn:shapes:plant-tissue-vouchering-standard-protocol-shapes:shortest-distance-between-replicates:feature-type>
+    a
+        sh:PropertyShape ,
+        urnc:Requirement ;
+    dcterms:source "Ecological Monitoring System - Australia Protocols" ;
+    reg:status reg:statusSubmitted ;
+    sh:description "TERN's ecologists have determined the feature type is _plant population_, defined by the link:https://www.publish.csiro.au/book/5230/[Australian Soil and Land Survey Field Handbook]." ;
+    sh:hasValue <http://linked.data.gov.au/def/tern-cv/ae71c3f6-d430-400f-a1d4-97a333b4ee02> ;
+    sh:message "The value of `tern:featureType` _MUST_ be link: http://linked.data.gov.au/def/tern-cv/ae71c3f6-d430-400f-a1d4-97a333b4ee02[`plant population`]." ;
+    sh:name "Feature type" ;
+    sh:path tern:featureType ;
+    sh:target [
+            a sh:SPARQLTarget ;
+            sh:select """
+    PREFIX tern: <https://w3id.org/tern/ontologies/tern/>
+    PREFIX unit: <http://qudt.org/vocab/unit/>
+    PREFIX sosa: <http://www.w3.org/ns/sosa/>
+    select ?this  {
+        values ?property_uri {<https://linked.data.gov.au/def/nrm/3b2aa21d-c60f-45c5-9447-ff8a799a513e>}
+        ?observation a tern:Observation ;
+            sosa:observedProperty ?property_uri ;
+            sosa:hasFeatureOfInterest ?this .
+    }
+    """
+        ] ;
+    urnp:examples _:nbd42ee23fe394fdba3d0cb52ab4bf1afb2 ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plant-tissue-vouchering/plant-tissue-vouchering-standard-protocol-shapes/shortest-distance-between-replicates/shapes.ttl"^^xsd:anyURI ;
+.
+
+<urn:shapes:plant-tissue-vouchering-standard-protocol-shapes:shortest-distance-between-replicates:simple-result>
+    a
+        sh:NodeShape ,
+        urnc:Requirement ;
+    dcterms:source "Ecological Monitoring System - Australia Protocols" ;
+    reg:status reg:statusSubmitted ;
+    sh:description "Value of `sosa:hasSimpleResult` _MUST_ be the same as the value in `sosa:hasResult`." ;
+    sh:message "The observation's `sosa:hasSimpleResult` _MUST_ have a value that is the same as the value in the value node of `sosa:hasResult`." ;
+    sh:name "Simple result" ;
+    sh:sparql [
+            sh:select """
+    PREFIX tern: <https://w3id.org/tern/ontologies/tern/>
+    PREFIX unit: <http://qudt.org/vocab/unit/>
+    PREFIX sosa: <http://www.w3.org/ns/sosa/>
+    PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+    select $this {
+        $this a tern:Observation ;
+            sosa:observedProperty 
+    <https://linked.data.gov.au/def/nrm/3b2aa21d-c60f-45c5-9447-ff8a799a513e>
+     ;
+            sosa:hasSimpleResult ?simple ;
+            sosa:hasResult ?result .
+        ?result rdf:value ?value .
+        filter (?simple != ?value)
+    }
+    """
+        ] ;
+    sh:targetClass tern:Observation ;
+    urnp:examples _:nbd42ee23fe394fdba3d0cb52ab4bf1afb2 ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plant-tissue-vouchering/plant-tissue-vouchering-standard-protocol-shapes/shortest-distance-between-replicates/shapes.ttl"^^xsd:anyURI ;
+.
+
+<urn:shapes:plant-tissue-vouchering-standard-protocol-shapes:shortest-distance-between-replicates:site-visit>
+    a
+        sh:PropertyShape ,
+        urnc:Requirement ;
+    dcterms:source "Ecological Monitoring System - Australia Protocols" ;
+    reg:status reg:statusSubmitted ;
+    sh:description "Observations following the Plant Tissue Vouchering - Standard Protocol are made in the context of a site visit." ;
+    sh:maxCount 1 ;
+    sh:message "Observations _MUST_ have a value for `tern:hasSiteVisit`." ;
+    sh:minCount 1 ;
+    sh:name "Site visit" ;
+    sh:path tern:hasSiteVisit ;
+    sh:target [
+            a sh:SPARQLTarget ;
+            sh:select """
+    PREFIX tern: <https://w3id.org/tern/ontologies/tern/>
+    PREFIX unit: <http://qudt.org/vocab/unit/>
+    PREFIX sosa: <http://www.w3.org/ns/sosa/>
+    PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+    select ?this {
+        values ?property_uri {<https://linked.data.gov.au/def/nrm/3b2aa21d-c60f-45c5-9447-ff8a799a513e>}
+        ?this a tern:Observation ;
+            sosa:observedProperty ?property_uri .
+    }
+    """
+        ] ;
+    urnp:examples _:nbd42ee23fe394fdba3d0cb52ab4bf1afb2 ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plant-tissue-vouchering/plant-tissue-vouchering-standard-protocol-shapes/shortest-distance-between-replicates/shapes.ttl"^^xsd:anyURI ;
+.
+
+<urn:shapes:plant-tissue-vouchering-standard-protocol-shapes:shortest-distance-between-replicates:unit-of-measure>
+    a
+        sh:PropertyShape ,
+        urnc:Requirement ;
+    dcterms:source "Ecological Monitoring System - Australia Protocols" ;
+    reg:status reg:statusSubmitted ;
+    sh:description "Result value's unit of measure _MUST_ have the value `unit:M`." ;
+    sh:hasValue unit:M ;
+    sh:message "The result _MUST_ have `unit:M` as the value for `tern:unit`." ;
+    sh:name "Unit of measure" ;
+    sh:path tern:unit ;
+    sh:target [
+            a sh:SPARQLTarget ;
+            sh:select """
+        PREFIX tern: <https://w3id.org/tern/ontologies/tern/>
+        PREFIX sosa: <http://www.w3.org/ns/sosa/>
+        PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+        select ?this  {
+            ?observation a tern:Observation ;
+                sosa:observedProperty 
+        <https://linked.data.gov.au/def/nrm/3b2aa21d-c60f-45c5-9447-ff8a799a513e> ;
+                sosa:hasResult ?this .
+        }"""
+        ] ;
+    urnp:examples _:nbd42ee23fe394fdba3d0cb52ab4bf1afb2 ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plant-tissue-vouchering/plant-tissue-vouchering-standard-protocol-shapes/shortest-distance-between-replicates/shapes.ttl"^^xsd:anyURI ;
+.
+
+<urn:shapes:plant-tissue-vouchering-standard-protocol-shapes:shortest-distance-between-replicates:used-procedure>
+    a
+        sh:PropertyShape ,
+        urnc:Requirement ;
+    dcterms:source "Ecological Monitoring System - Australia Protocols" ;
+    reg:status reg:statusSubmitted ;
+    sh:description """IRI of method in procedure _MUST_ have the value `<https://linked.data.gov.au/def/nrm/c20d9a04-702d-429a-ab5f-d7424cd2990d>`.
+
+    `<https://linked.data.gov.au/def/nrm/c20d9a04-702d-429a-ab5f-d7424cd2990d>` is the IRI for "Plant Tissue Vouchering - Standard Protocol".""" ;
+    sh:hasValue <https://linked.data.gov.au/def/nrm/c20d9a04-702d-429a-ab5f-d7424cd2990d> ;
+    sh:message "The procedure's `tern:methodType` _MUST_ have the value `https://linked.data.gov.au/def/nrm/c20d9a04-702d-429a-ab5f-d7424cd2990d`." ;
+    sh:name "Method type of used procedure" ;
+    sh:path tern:methodType ;
+    sh:target [
+            a sh:SPARQLTarget ;
+            sh:select """
+    PREFIX tern: <https://w3id.org/tern/ontologies/tern/>
+    PREFIX unit: <http://qudt.org/vocab/unit/>
+    PREFIX sosa: <http://www.w3.org/ns/sosa/>
+    PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+    select ?this {
+        values ?property_uri {<https://linked.data.gov.au/def/nrm/3b2aa21d-c60f-45c5-9447-ff8a799a513e>}
+        ?observation a tern:Observation ;
+            sosa:observedProperty ?property_uri ;
+            sosa:usedProcedure ?this .
+    }
+    """
+        ] ;
+    urnp:examples _:nbd42ee23fe394fdba3d0cb52ab4bf1afb2 ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plant-tissue-vouchering/plant-tissue-vouchering-standard-protocol-shapes/shortest-distance-between-replicates/shapes.ttl"^^xsd:anyURI ;
+.
+
+<urn:shapes:plant-tissue-vouchering-standard-protocol-shapes:shortest-distance-between-replicates:value-range>
+    a
+        sh:PropertyShape ,
+        urnc:Requirement ;
+    dcterms:source "Ecological Monitoring System - Australia Protocols" ;
+    reg:status reg:statusSubmitted ;
+    sh:datatype xsd:float ;
+    sh:description "Value _MUST_ be between 0 exclusive and 100 inclusive." ;
+    sh:maxInclusive 100 ;
+    sh:message "The result _MUST_ have a value between 0 exclusively and 100 inclusively." ;
+    sh:minExclusive 0 ;
+    sh:name "Value range" ;
+    sh:path rdf:value ;
+    sh:target [
+            a sh:SPARQLTarget ;
+            sh:select """
+        PREFIX tern: <https://w3id.org/tern/ontologies/tern/>
+        PREFIX sosa: <http://www.w3.org/ns/sosa/>
+        PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+        select ?this  {
+            ?observation a tern:Observation ;
+                sosa:observedProperty 
+        <https://linked.data.gov.au/def/nrm/3b2aa21d-c60f-45c5-9447-ff8a799a513e> ;
+                sosa:hasResult ?this .
+        }"""
+        ] ;
+    urnp:examples _:nbd42ee23fe394fdba3d0cb52ab4bf1afb2 ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plant-tissue-vouchering/plant-tissue-vouchering-standard-protocol-shapes/shortest-distance-between-replicates/shapes.ttl"^^xsd:anyURI ;
+.
+
+<urn:shapes:plant-tissue-vouchering-standard-protocol-shapes:shortest-distance-between-replicates:value-type>
+    a
+        sh:PropertyShape ,
+        urnc:Requirement ;
+    dcterms:source "Ecological Monitoring System - Australia Protocols" ;
+    reg:status reg:statusSubmitted ;
+    sh:class tern:Float ;
+    sh:description "The value of `sosa:hasResult` _MUST_ be a `tern:Float`." ;
+    sh:message "The result _MUST_ be an instance of `tern:Float`." ;
+    sh:name "Value type" ;
+    sh:path sosa:hasResult ;
+    sh:target [
+            a sh:SPARQLTarget ;
+            sh:select """
+    PREFIX tern: <https://w3id.org/tern/ontologies/tern/>
+    PREFIX unit: <http://qudt.org/vocab/unit/>
+    PREFIX sosa: <http://www.w3.org/ns/sosa/>
+    PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+    select ?this {
+        values ?property_uri {<https://linked.data.gov.au/def/nrm/3b2aa21d-c60f-45c5-9447-ff8a799a513e>}
+        ?this a tern:Observation ;
+            sosa:observedProperty ?property_uri .
+    }
+    """
+        ] ;
+    urnp:examples _:nbd42ee23fe394fdba3d0cb52ab4bf1afb2 ;
+    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plant-tissue-vouchering/plant-tissue-vouchering-standard-protocol-shapes/shortest-distance-between-replicates/shapes.ttl"^^xsd:anyURI ;
+.
+
+_:nbd42ee23fe394fdba3d0cb52ab4bf1afb2
+    urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plant-tissue-vouchering/plant-tissue-vouchering-standard-protocol-shapes/shortest-distance-between-replicates/invalid.ttl"^^xsd:anyURI ;
+    urnp:validExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plant-tissue-vouchering/plant-tissue-vouchering-standard-protocol-shapes/shortest-distance-between-replicates/valid.ttl"^^xsd:anyURI ;
+.
+

--- a/shapes/plot-description/plot-description-enhanced-protocol-shapes/land-use-history/invalid.ttl
+++ b/shapes/plot-description/plot-description-enhanced-protocol-shapes/land-use-history/invalid.ttl
@@ -25,7 +25,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                 tern:Value ;
             rdf:value <http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Conservation-and-natural-environments> ;
             sosa:isResultOf <urn:test:plot-description-enhanced-protocol-shapes:invalid:land-use-history:feature-type> ;
-            tern:vocabulary <http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Australian-Land-Use-and-Management-Classification>
+            # tern:vocabulary <http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Australian-Land-Use-and-Management-Classification>
         ] ;
     sosa:hasSimpleResult <http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Conservation-and-natural-environments> ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/372ec5c5-79da-44a9-a56e-dd9ab311da06> ;
@@ -50,7 +50,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                 tern:Value ;
             rdf:value <urn:fake:categorical:value> ;
             sosa:isResultOf <urn:test:plot-description-enhanced-protocol-shapes:invalid:land-use-history:result-value> ;
-            tern:vocabulary <http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Australian-Land-Use-and-Management-Classification>
+            # tern:vocabulary <http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Australian-Land-Use-and-Management-Classification>
         ] ;
     sosa:hasSimpleResult <urn:fake:categorical:value> ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/372ec5c5-79da-44a9-a56e-dd9ab311da06> ;
@@ -75,7 +75,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                 tern:Value ;
             rdf:value <http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Conservation-and-natural-environments> ;
             sosa:isResultOf <urn:test:plot-description-enhanced-protocol-shapes:invalid:land-use-history:simple-result> ;
-            tern:vocabulary <http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Australian-Land-Use-and-Management-Classification>
+            # tern:vocabulary <http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Australian-Land-Use-and-Management-Classification>
         ] ;
     sosa:hasSimpleResult <urn:fake:categorical:value> ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/372ec5c5-79da-44a9-a56e-dd9ab311da06> ;
@@ -100,7 +100,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                 tern:Value ;
             rdf:value <http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Conservation-and-natural-environments> ;
             sosa:isResultOf <urn:test:plot-description-enhanced-protocol-shapes:invalid:land-use-history:site-visit> ;
-            tern:vocabulary <http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Australian-Land-Use-and-Management-Classification>
+            # tern:vocabulary <http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Australian-Land-Use-and-Management-Classification>
         ] ;
     sosa:hasSimpleResult <http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Conservation-and-natural-environments> ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/372ec5c5-79da-44a9-a56e-dd9ab311da06> ;
@@ -124,7 +124,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                 tern:Value ;
             rdf:value <http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Conservation-and-natural-environments> ;
             sosa:isResultOf <urn:test:plot-description-enhanced-protocol-shapes:invalid:land-use-history:used-procedure> ;
-            tern:vocabulary <http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Australian-Land-Use-and-Management-Classification>
+            # tern:vocabulary <http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Australian-Land-Use-and-Management-Classification>
         ] ;
     sosa:hasSimpleResult <http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Conservation-and-natural-environments> ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/372ec5c5-79da-44a9-a56e-dd9ab311da06> ;
@@ -147,7 +147,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             a tern:Value ;
             rdf:value <http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Conservation-and-natural-environments> ;
             sosa:isResultOf <urn:test:plot-description-enhanced-protocol-shapes:invalid:land-use-history:value-type> ;
-            tern:vocabulary <http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Australian-Land-Use-and-Management-Classification>
+            # tern:vocabulary <http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Australian-Land-Use-and-Management-Classification>
         ] ;
     sosa:hasSimpleResult <http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Conservation-and-natural-environments> ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/372ec5c5-79da-44a9-a56e-dd9ab311da06> ;
@@ -172,7 +172,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                 tern:Value ;
             rdf:value <http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Conservation-and-natural-environments> ;
             sosa:isResultOf <urn:test:plot-description-enhanced-protocol-shapes:invalid:land-use-history:vocabulary> ;
-            tern:vocabulary <urn:fake:vocabulary>
+            # tern:vocabulary <urn:fake:vocabulary>
         ] ;
     sosa:hasSimpleResult <http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Conservation-and-natural-environments> ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/372ec5c5-79da-44a9-a56e-dd9ab311da06> ;

--- a/shapes/plot-description/plot-description-enhanced-protocol-shapes/land-use-history/shapes.ttl
+++ b/shapes/plot-description/plot-description-enhanced-protocol-shapes/land-use-history/shapes.ttl
@@ -387,35 +387,35 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/plot-description-enhanced-protocol-shapes/land-use-history/shapes.ttl"^^xsd:anyURI ;
 .
 
-<urn:shapes:plot-description-enhanced-protocol-shapes:land-use-history:vocabulary>
-    a
-        sh:PropertyShape ,
-        urnc:Requirement ;
-    dcterms:source "Ecological Monitoring System - Australia Protocols" ;
-    reg:status reg:statusSubmitted ;
-    sh:description """IRI of `tern:vocabulary` in `sosa:hasResult` _MUST_ have the value `<http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Australian-Land-Use-and-Management-Classification>`.
+# <urn:shapes:plot-description-enhanced-protocol-shapes:land-use-history:vocabulary>
+#     a
+#         sh:PropertyShape ,
+#         urnc:Requirement ;
+#     dcterms:source "Ecological Monitoring System - Australia Protocols" ;
+#     reg:status reg:statusSubmitted ;
+#     sh:description """IRI of `tern:vocabulary` in `sosa:hasResult` _MUST_ have the value `<http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Australian-Land-Use-and-Management-Classification>`.
 
-        `<http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Australian-Land-Use-and-Management-Classification>` is the IRI for "Australian Land Use and Management Classification".""" ;
-    sh:hasValue <http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Australian-Land-Use-and-Management-Classification> ;
-    sh:message "The value of `tern:vocabulary` _MUST_ be <http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Australian-Land-Use-and-Management-Classification>." ;
-    sh:name "Vocabulary" ;
-    sh:path tern:vocabulary ;
-    sh:target [
-            a sh:SPARQLTarget ;
-            sh:select """
-        PREFIX tern: <https://w3id.org/tern/ontologies/tern/>
-        PREFIX sosa: <http://www.w3.org/ns/sosa/>
-        PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-        select ?this  {
-            ?observation a tern:Observation ;
-                sosa:observedProperty 
-        <https://linked.data.gov.au/def/nrm/372ec5c5-79da-44a9-a56e-dd9ab311da06> ;
-                sosa:hasResult ?this .
-        }"""
-        ] ;
-    urnp:examples _:n91612dddddb444b5a25a0889a4fac9a1b2 ;
-    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/plot-description-enhanced-protocol-shapes/land-use-history/shapes.ttl"^^xsd:anyURI ;
-.
+#         `<http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Australian-Land-Use-and-Management-Classification>` is the IRI for "Australian Land Use and Management Classification".""" ;
+#     sh:hasValue <http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Australian-Land-Use-and-Management-Classification> ;
+#     sh:message "The value of `tern:vocabulary` _MUST_ be <http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Australian-Land-Use-and-Management-Classification>." ;
+#     sh:name "Vocabulary" ;
+#     sh:path tern:vocabulary ;
+#     sh:target [
+#             a sh:SPARQLTarget ;
+#             sh:select """
+#         PREFIX tern: <https://w3id.org/tern/ontologies/tern/>
+#         PREFIX sosa: <http://www.w3.org/ns/sosa/>
+#         PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+#         select ?this  {
+#             ?observation a tern:Observation ;
+#                 sosa:observedProperty 
+#         <https://linked.data.gov.au/def/nrm/372ec5c5-79da-44a9-a56e-dd9ab311da06> ;
+#                 sosa:hasResult ?this .
+#         }"""
+#         ] ;
+#     urnp:examples _:n91612dddddb444b5a25a0889a4fac9a1b2 ;
+#     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/plot-description-enhanced-protocol-shapes/land-use-history/shapes.ttl"^^xsd:anyURI ;
+# .
 
 _:n91612dddddb444b5a25a0889a4fac9a1b2
     urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/plot-description-enhanced-protocol-shapes/land-use-history/invalid.ttl"^^xsd:anyURI ;

--- a/shapes/plot-description/plot-description-enhanced-protocol-shapes/land-use-history/valid.ttl
+++ b/shapes/plot-description/plot-description-enhanced-protocol-shapes/land-use-history/valid.ttl
@@ -20,7 +20,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                 tern:Value ;
             rdf:value <http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Conservation-and-natural-environments> ;
             sosa:isResultOf <urn:test:plot-description-enhanced-protocol-shapes:valid:land-use-history> ;
-            tern:vocabulary <http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Australian-Land-Use-and-Management-Classification>
+            # tern:vocabulary <http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Australian-Land-Use-and-Management-Classification>
         ] ;
     sosa:hasSimpleResult <http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Conservation-and-natural-environments> ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/372ec5c5-79da-44a9-a56e-dd9ab311da06> ;

--- a/shapes/plot-description/plot-description-enhanced-protocol-shapes/shapes.ttl
+++ b/shapes/plot-description/plot-description-enhanced-protocol-shapes/shapes.ttl
@@ -2160,35 +2160,35 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/plot-description-enhanced-protocol-shapes/land-use-history/shapes.ttl"^^xsd:anyURI ;
 .
 
-<urn:shapes:plot-description-enhanced-protocol-shapes:land-use-history:vocabulary>
-    a
-        sh:PropertyShape ,
-        urnc:Requirement ;
-    dcterms:source "Ecological Monitoring System - Australia Protocols" ;
-    reg:status reg:statusSubmitted ;
-    sh:description """IRI of `tern:vocabulary` in `sosa:hasResult` _MUST_ have the value `<http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Australian-Land-Use-and-Management-Classification>`.
+# <urn:shapes:plot-description-enhanced-protocol-shapes:land-use-history:vocabulary>
+#     a
+#         sh:PropertyShape ,
+#         urnc:Requirement ;
+#     dcterms:source "Ecological Monitoring System - Australia Protocols" ;
+#     reg:status reg:statusSubmitted ;
+#     sh:description """IRI of `tern:vocabulary` in `sosa:hasResult` _MUST_ have the value `<http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Australian-Land-Use-and-Management-Classification>`.
 
-        `<http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Australian-Land-Use-and-Management-Classification>` is the IRI for "Australian Land Use and Management Classification".""" ;
-    sh:hasValue <http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Australian-Land-Use-and-Management-Classification> ;
-    sh:message "The value of `tern:vocabulary` _MUST_ be <http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Australian-Land-Use-and-Management-Classification>." ;
-    sh:name "Vocabulary" ;
-    sh:path tern:vocabulary ;
-    sh:target [
-            a sh:SPARQLTarget ;
-            sh:select """
-        PREFIX tern: <https://w3id.org/tern/ontologies/tern/>
-        PREFIX sosa: <http://www.w3.org/ns/sosa/>
-        PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-        select ?this  {
-            ?observation a tern:Observation ;
-                sosa:observedProperty 
-        <https://linked.data.gov.au/def/nrm/372ec5c5-79da-44a9-a56e-dd9ab311da06> ;
-                sosa:hasResult ?this .
-        }"""
-        ] ;
-    urnp:examples _:na55bd4f9856a4bd591dbec4b8c19f5f1b173 ;
-    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/plot-description-enhanced-protocol-shapes/land-use-history/shapes.ttl"^^xsd:anyURI ;
-.
+#         `<http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Australian-Land-Use-and-Management-Classification>` is the IRI for "Australian Land Use and Management Classification".""" ;
+#     sh:hasValue <http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Australian-Land-Use-and-Management-Classification> ;
+#     sh:message "The value of `tern:vocabulary` _MUST_ be <http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Australian-Land-Use-and-Management-Classification>." ;
+#     sh:name "Vocabulary" ;
+#     sh:path tern:vocabulary ;
+#     sh:target [
+#             a sh:SPARQLTarget ;
+#             sh:select """
+#         PREFIX tern: <https://w3id.org/tern/ontologies/tern/>
+#         PREFIX sosa: <http://www.w3.org/ns/sosa/>
+#         PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+#         select ?this  {
+#             ?observation a tern:Observation ;
+#                 sosa:observedProperty 
+#         <https://linked.data.gov.au/def/nrm/372ec5c5-79da-44a9-a56e-dd9ab311da06> ;
+#                 sosa:hasResult ?this .
+#         }"""
+#         ] ;
+#     urnp:examples _:na55bd4f9856a4bd591dbec4b8c19f5f1b173 ;
+#     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/plot-description-enhanced-protocol-shapes/land-use-history/shapes.ttl"^^xsd:anyURI ;
+# .
 
 <urn:shapes:plot-description-enhanced-protocol-shapes:landform-element:feature-type>
     a

--- a/shapes/plot-description/shapes.ttl
+++ b/shapes/plot-description/shapes.ttl
@@ -2160,35 +2160,35 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/plot-description-enhanced-protocol-shapes/land-use-history/shapes.ttl"^^xsd:anyURI ;
 .
 
-<urn:shapes:plot-description-enhanced-protocol-shapes:land-use-history:vocabulary>
-    a
-        sh:PropertyShape ,
-        urnc:Requirement ;
-    dcterms:source "Ecological Monitoring System - Australia Protocols" ;
-    reg:status reg:statusSubmitted ;
-    sh:description """IRI of `tern:vocabulary` in `sosa:hasResult` _MUST_ have the value `<http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Australian-Land-Use-and-Management-Classification>`.
+# <urn:shapes:plot-description-enhanced-protocol-shapes:land-use-history:vocabulary>
+#     a
+#         sh:PropertyShape ,
+#         urnc:Requirement ;
+#     dcterms:source "Ecological Monitoring System - Australia Protocols" ;
+#     reg:status reg:statusSubmitted ;
+#     sh:description """IRI of `tern:vocabulary` in `sosa:hasResult` _MUST_ have the value `<http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Australian-Land-Use-and-Management-Classification>`.
 
-        `<http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Australian-Land-Use-and-Management-Classification>` is the IRI for "Australian Land Use and Management Classification".""" ;
-    sh:hasValue <http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Australian-Land-Use-and-Management-Classification> ;
-    sh:message "The value of `tern:vocabulary` _MUST_ be <http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Australian-Land-Use-and-Management-Classification>." ;
-    sh:name "Vocabulary" ;
-    sh:path tern:vocabulary ;
-    sh:target [
-            a sh:SPARQLTarget ;
-            sh:select """
-        PREFIX tern: <https://w3id.org/tern/ontologies/tern/>
-        PREFIX sosa: <http://www.w3.org/ns/sosa/>
-        PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-        select ?this  {
-            ?observation a tern:Observation ;
-                sosa:observedProperty 
-        <https://linked.data.gov.au/def/nrm/372ec5c5-79da-44a9-a56e-dd9ab311da06> ;
-                sosa:hasResult ?this .
-        }"""
-        ] ;
-    urnp:examples _:ndb2597178d4e4c9792b6644a540d3f69b173 ;
-    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/plot-description-enhanced-protocol-shapes/land-use-history/shapes.ttl"^^xsd:anyURI ;
-.
+#         `<http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Australian-Land-Use-and-Management-Classification>` is the IRI for "Australian Land Use and Management Classification".""" ;
+#     sh:hasValue <http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Australian-Land-Use-and-Management-Classification> ;
+#     sh:message "The value of `tern:vocabulary` _MUST_ be <http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Australian-Land-Use-and-Management-Classification>." ;
+#     sh:name "Vocabulary" ;
+#     sh:path tern:vocabulary ;
+#     sh:target [
+#             a sh:SPARQLTarget ;
+#             sh:select """
+#         PREFIX tern: <https://w3id.org/tern/ontologies/tern/>
+#         PREFIX sosa: <http://www.w3.org/ns/sosa/>
+#         PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+#         select ?this  {
+#             ?observation a tern:Observation ;
+#                 sosa:observedProperty 
+#         <https://linked.data.gov.au/def/nrm/372ec5c5-79da-44a9-a56e-dd9ab311da06> ;
+#                 sosa:hasResult ?this .
+#         }"""
+#         ] ;
+#     urnp:examples _:ndb2597178d4e4c9792b6644a540d3f69b173 ;
+#     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/plot-description/plot-description-enhanced-protocol-shapes/land-use-history/shapes.ttl"^^xsd:anyURI ;
+# .
 
 <urn:shapes:plot-description-enhanced-protocol-shapes:landform-element:feature-type>
     a

--- a/shapes/vegetation-mapping-protocol-shapes/land-use-history/invalid.ttl
+++ b/shapes/vegetation-mapping-protocol-shapes/land-use-history/invalid.ttl
@@ -25,7 +25,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                 tern:Value ;
             rdf:value <http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Conservation-and-natural-environments> ;
             sosa:isResultOf <urn:test:vegetation-mapping-protocol-shapes:invalid:land-use-history:feature-type> ;
-            tern:vocabulary <http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Australian-Land-Use-and-Management-Classification>
+            # tern:vocabulary <http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Australian-Land-Use-and-Management-Classification>
         ] ;
     sosa:hasSimpleResult <http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Conservation-and-natural-environments> ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/372ec5c5-79da-44a9-a56e-dd9ab311da06> ;
@@ -49,7 +49,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                 tern:Value ;
             rdf:value <urn:fake:categorical:value> ;
             sosa:isResultOf <urn:test:vegetation-mapping-protocol-shapes:invalid:land-use-history:result-value> ;
-            tern:vocabulary <http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Australian-Land-Use-and-Management-Classification>
+            # tern:vocabulary <http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Australian-Land-Use-and-Management-Classification>
         ] ;
     sosa:hasSimpleResult <urn:fake:categorical:value> ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/372ec5c5-79da-44a9-a56e-dd9ab311da06> ;
@@ -73,7 +73,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                 tern:Value ;
             rdf:value <http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Conservation-and-natural-environments> ;
             sosa:isResultOf <urn:test:vegetation-mapping-protocol-shapes:invalid:land-use-history:simple-result> ;
-            tern:vocabulary <http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Australian-Land-Use-and-Management-Classification>
+            # tern:vocabulary <http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Australian-Land-Use-and-Management-Classification>
         ] ;
     sosa:hasSimpleResult <urn:fake:categorical:value> ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/372ec5c5-79da-44a9-a56e-dd9ab311da06> ;
@@ -97,7 +97,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                 tern:Value ;
             rdf:value <http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Conservation-and-natural-environments> ;
             sosa:isResultOf <urn:test:vegetation-mapping-protocol-shapes:invalid:land-use-history:used-procedure> ;
-            tern:vocabulary <http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Australian-Land-Use-and-Management-Classification>
+            # tern:vocabulary <http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Australian-Land-Use-and-Management-Classification>
         ] ;
     sosa:hasSimpleResult <http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Conservation-and-natural-environments> ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/372ec5c5-79da-44a9-a56e-dd9ab311da06> ;
@@ -119,7 +119,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             a tern:Value ;
             rdf:value <http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Conservation-and-natural-environments> ;
             sosa:isResultOf <urn:test:vegetation-mapping-protocol-shapes:invalid:land-use-history:value-type> ;
-            tern:vocabulary <http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Australian-Land-Use-and-Management-Classification>
+            # tern:vocabulary <http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Australian-Land-Use-and-Management-Classification>
         ] ;
     sosa:hasSimpleResult <http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Conservation-and-natural-environments> ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/372ec5c5-79da-44a9-a56e-dd9ab311da06> ;
@@ -143,7 +143,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                 tern:Value ;
             rdf:value <http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Conservation-and-natural-environments> ;
             sosa:isResultOf <urn:test:vegetation-mapping-protocol-shapes:invalid:land-use-history:vocabulary> ;
-            tern:vocabulary <urn:fake:vocabulary>
+            # tern:vocabulary <urn:fake:vocabulary>
         ] ;
     sosa:hasSimpleResult <http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Conservation-and-natural-environments> ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/372ec5c5-79da-44a9-a56e-dd9ab311da06> ;

--- a/shapes/vegetation-mapping-protocol-shapes/land-use-history/shapes.ttl
+++ b/shapes/vegetation-mapping-protocol-shapes/land-use-history/shapes.ttl
@@ -357,35 +357,35 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/vegetation-mapping-protocol-shapes/land-use-history/shapes.ttl"^^xsd:anyURI ;
 .
 
-<urn:shapes:vegetation-mapping-protocol-shapes:land-use-history:vocabulary>
-    a
-        sh:PropertyShape ,
-        urnc:Requirement ;
-    dcterms:source "Ecological Monitoring System - Australia Protocols" ;
-    reg:status reg:statusSubmitted ;
-    sh:description """IRI of `tern:vocabulary` in `sosa:hasResult` _MUST_ have the value `<http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Australian-Land-Use-and-Management-Classification>`.
+# <urn:shapes:vegetation-mapping-protocol-shapes:land-use-history:vocabulary>
+#     a
+#         sh:PropertyShape ,
+#         urnc:Requirement ;
+#     dcterms:source "Ecological Monitoring System - Australia Protocols" ;
+#     reg:status reg:statusSubmitted ;
+#     sh:description """IRI of `tern:vocabulary` in `sosa:hasResult` _MUST_ have the value `<http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Australian-Land-Use-and-Management-Classification>`.
 
-        `<http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Australian-Land-Use-and-Management-Classification>` is the IRI for "Australian Land Use and Management Classification".""" ;
-    sh:hasValue <http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Australian-Land-Use-and-Management-Classification> ;
-    sh:message "The value of `tern:vocabulary` _MUST_ be <http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Australian-Land-Use-and-Management-Classification>." ;
-    sh:name "Vocabulary" ;
-    sh:path tern:vocabulary ;
-    sh:target [
-            a sh:SPARQLTarget ;
-            sh:select """
-        PREFIX tern: <https://w3id.org/tern/ontologies/tern/>
-        PREFIX sosa: <http://www.w3.org/ns/sosa/>
-        PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-        select ?this  {
-            ?observation a tern:Observation ;
-                sosa:observedProperty 
-        <https://linked.data.gov.au/def/nrm/372ec5c5-79da-44a9-a56e-dd9ab311da06> ;
-                sosa:hasResult ?this .
-        }"""
-        ] ;
-    urnp:examples _:n5701dc34643b4907ac010ea53a3108fdb2 ;
-    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/vegetation-mapping-protocol-shapes/land-use-history/shapes.ttl"^^xsd:anyURI ;
-.
+#         `<http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Australian-Land-Use-and-Management-Classification>` is the IRI for "Australian Land Use and Management Classification".""" ;
+#     sh:hasValue <http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Australian-Land-Use-and-Management-Classification> ;
+#     sh:message "The value of `tern:vocabulary` _MUST_ be <http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Australian-Land-Use-and-Management-Classification>." ;
+#     sh:name "Vocabulary" ;
+#     sh:path tern:vocabulary ;
+#     sh:target [
+#             a sh:SPARQLTarget ;
+#             sh:select """
+#         PREFIX tern: <https://w3id.org/tern/ontologies/tern/>
+#         PREFIX sosa: <http://www.w3.org/ns/sosa/>
+#         PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+#         select ?this  {
+#             ?observation a tern:Observation ;
+#                 sosa:observedProperty 
+#         <https://linked.data.gov.au/def/nrm/372ec5c5-79da-44a9-a56e-dd9ab311da06> ;
+#                 sosa:hasResult ?this .
+#         }"""
+#         ] ;
+#     urnp:examples _:n5701dc34643b4907ac010ea53a3108fdb2 ;
+#     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/vegetation-mapping-protocol-shapes/land-use-history/shapes.ttl"^^xsd:anyURI ;
+# .
 
 _:n5701dc34643b4907ac010ea53a3108fdb2
     urnp:invalidExample "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/vegetation-mapping-protocol-shapes/land-use-history/invalid.ttl"^^xsd:anyURI ;

--- a/shapes/vegetation-mapping-protocol-shapes/land-use-history/valid.ttl
+++ b/shapes/vegetation-mapping-protocol-shapes/land-use-history/valid.ttl
@@ -25,7 +25,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                 tern:Value ;
             rdf:value <http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Conservation-and-natural-environments> ;
             sosa:isResultOf <urn:test:vegetation-mapping-protocol-shapes:valid:land-use-history> ;
-            tern:vocabulary <http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Australian-Land-Use-and-Management-Classification>
+            # tern:vocabulary <http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Australian-Land-Use-and-Management-Classification>
         ] ;
     sosa:hasSimpleResult <http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Conservation-and-natural-environments> ;
     sosa:observedProperty <https://linked.data.gov.au/def/nrm/372ec5c5-79da-44a9-a56e-dd9ab311da06> ;

--- a/shapes/vegetation-mapping-protocol-shapes/shapes.ttl
+++ b/shapes/vegetation-mapping-protocol-shapes/shapes.ttl
@@ -1658,35 +1658,35 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/vegetation-mapping-protocol-shapes/land-use-history/shapes.ttl"^^xsd:anyURI ;
 .
 
-<urn:shapes:vegetation-mapping-protocol-shapes:land-use-history:vocabulary>
-    a
-        sh:PropertyShape ,
-        urnc:Requirement ;
-    dcterms:source "Ecological Monitoring System - Australia Protocols" ;
-    reg:status reg:statusSubmitted ;
-    sh:description """IRI of `tern:vocabulary` in `sosa:hasResult` _MUST_ have the value `<http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Australian-Land-Use-and-Management-Classification>`.
+# <urn:shapes:vegetation-mapping-protocol-shapes:land-use-history:vocabulary>
+#     a
+#         sh:PropertyShape ,
+#         urnc:Requirement ;
+#     dcterms:source "Ecological Monitoring System - Australia Protocols" ;
+#     reg:status reg:statusSubmitted ;
+#     sh:description """IRI of `tern:vocabulary` in `sosa:hasResult` _MUST_ have the value `<http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Australian-Land-Use-and-Management-Classification>`.
 
-        `<http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Australian-Land-Use-and-Management-Classification>` is the IRI for "Australian Land Use and Management Classification".""" ;
-    sh:hasValue <http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Australian-Land-Use-and-Management-Classification> ;
-    sh:message "The value of `tern:vocabulary` _MUST_ be <http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Australian-Land-Use-and-Management-Classification>." ;
-    sh:name "Vocabulary" ;
-    sh:path tern:vocabulary ;
-    sh:target [
-            a sh:SPARQLTarget ;
-            sh:select """
-        PREFIX tern: <https://w3id.org/tern/ontologies/tern/>
-        PREFIX sosa: <http://www.w3.org/ns/sosa/>
-        PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-        select ?this  {
-            ?observation a tern:Observation ;
-                sosa:observedProperty 
-        <https://linked.data.gov.au/def/nrm/372ec5c5-79da-44a9-a56e-dd9ab311da06> ;
-                sosa:hasResult ?this .
-        }"""
-        ] ;
-    urnp:examples _:nd452f6815b7447bcbb37afd7d8f31154b87 ;
-    urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/vegetation-mapping-protocol-shapes/land-use-history/shapes.ttl"^^xsd:anyURI ;
-.
+#         `<http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Australian-Land-Use-and-Management-Classification>` is the IRI for "Australian Land Use and Management Classification".""" ;
+#     sh:hasValue <http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Australian-Land-Use-and-Management-Classification> ;
+#     sh:message "The value of `tern:vocabulary` _MUST_ be <http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/Australian-Land-Use-and-Management-Classification>." ;
+#     sh:name "Vocabulary" ;
+#     sh:path tern:vocabulary ;
+#     sh:target [
+#             a sh:SPARQLTarget ;
+#             sh:select """
+#         PREFIX tern: <https://w3id.org/tern/ontologies/tern/>
+#         PREFIX sosa: <http://www.w3.org/ns/sosa/>
+#         PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+#         select ?this  {
+#             ?observation a tern:Observation ;
+#                 sosa:observedProperty 
+#         <https://linked.data.gov.au/def/nrm/372ec5c5-79da-44a9-a56e-dd9ab311da06> ;
+#                 sosa:hasResult ?this .
+#         }"""
+#         ] ;
+#     urnp:examples _:nd452f6815b7447bcbb37afd7d8f31154b87 ;
+#     urnp:validator "https://github.com/ternaustralia/dawe-rlp-spec/blob/main/shapes/vegetation-mapping-protocol-shapes/land-use-history/shapes.ttl"^^xsd:anyURI ;
+# .
 
 <urn:shapes:vegetation-mapping-protocol-shapes:site-disturbance:feature-type>
     a

--- a/tests/manifests.py
+++ b/tests/manifests.py
@@ -1344,7 +1344,7 @@ test_cases: List[TestCaseItem] = [
         shapes_path="shapes/plot-description/plot-description-enhanced-protocol-shapes/land-use-history/shapes.ttl",
         valid_data_path="shapes/plot-description/plot-description-enhanced-protocol-shapes/land-use-history/valid.ttl",
         invalid_data_path="shapes/plot-description/plot-description-enhanced-protocol-shapes/land-use-history/invalid.ttl",
-        expected_failures=7,
+        expected_failures=6,
     ).astuple(),
     TestCaseItem(
         name="plot-description-enhanced-protocol-shapes-field-species-name",
@@ -2303,7 +2303,7 @@ test_cases: List[TestCaseItem] = [
         shapes_path="shapes/vegetation-mapping-protocol-shapes/land-use-history/shapes.ttl",
         valid_data_path="shapes/vegetation-mapping-protocol-shapes/land-use-history/valid.ttl",
         invalid_data_path="shapes/vegetation-mapping-protocol-shapes/land-use-history/invalid.ttl",
-        expected_failures=6,
+        expected_failures=5,
     ).astuple(),
     TestCaseItem(
         name="vegetation-mapping-protocol-shapes-foliage-projective-cover",


### PR DESCRIPTION
The ACLUM vocabulary relevant to Australia land use and management has been deprecated and the IRI is not working, so removed. Will bring it back when new IRI finalised.
There is only one observation in 2 sub protocols for `plant tissue vouchering`, so made copies of the shapes file to protocol level directly.