### PR TITLE
Updated LUTs for `voucher specimen type` in Opportune

### DIFF
--- a/shapes/opportunistic-observations-protocol-shapes/shapes.ttl
+++ b/shapes/opportunistic-observations-protocol-shapes/shapes.ttl
@@ -6362,14 +6362,14 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     reg:status reg:statusSubmitted ;
     sh:description "The value in `sosa:hasResult` _MUST_ be a value in `sh:in`, which is the Voucher specimen types controlled vocabulary." ;
     sh:in (
-            <https://linked.data.gov.au/def/nrm/9430fb9f-e9e0-5c2b-950c-e525fedb6908>
             <https://linked.data.gov.au/def/nrm/0edb44c6-71fe-5591-a0cc-0092ba4cacaa>
-            <https://linked.data.gov.au/def/nrm/f2abdf62-3f31-5932-ac6f-3e72f59ad44a>
             <https://linked.data.gov.au/def/nrm/a96d7507-e823-5f3a-a26b-62313538e0bb>
-            <https://linked.data.gov.au/def/nrm/5157de5b-e6ee-5843-8063-ba07a5a7e9d2>
-            <https://linked.data.gov.au/def/nrm/e3a4c141-a85e-58cc-bf8c-66c35d27f44f>
             <https://linked.data.gov.au/def/nrm/aa52280b-a63f-5a6d-b3bd-6045a379df00>
             <https://linked.data.gov.au/def/nrm/b4036db0-9852-5772-bff5-4dffccc829a0>
+            <https://linked.data.gov.au/def/nrm/5157de5b-e6ee-5843-8063-ba07a5a7e9d2>
+            <https://linked.data.gov.au/def/nrm/454dd8f1-00c8-4c22-9705-9d1f9c0e293d>
+            <https://linked.data.gov.au/def/nrm/4230d984-61df-459a-b36f-2b053b881c2d>
+            <https://linked.data.gov.au/def/nrm/f2abdf62-3f31-5932-ac6f-3e72f59ad44a>
         ) ;
     sh:message "The value of `rdf:value` _MUST_ exist in the Voucher specimen types controlled vocabulary." ;
     sh:name "Result value" ;

--- a/shapes/opportunistic-observations-protocol-shapes/voucher-specimen-type/shapes.ttl
+++ b/shapes/opportunistic-observations-protocol-shapes/voucher-specimen-type/shapes.ttl
@@ -49,14 +49,14 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     reg:status reg:statusSubmitted ;
     sh:description "The value in `sosa:hasResult` _MUST_ be a value in `sh:in`, which is the Voucher specimen types controlled vocabulary." ;
     sh:in (
-            <https://linked.data.gov.au/def/nrm/9430fb9f-e9e0-5c2b-950c-e525fedb6908>
             <https://linked.data.gov.au/def/nrm/0edb44c6-71fe-5591-a0cc-0092ba4cacaa>
-            <https://linked.data.gov.au/def/nrm/f2abdf62-3f31-5932-ac6f-3e72f59ad44a>
             <https://linked.data.gov.au/def/nrm/a96d7507-e823-5f3a-a26b-62313538e0bb>
-            <https://linked.data.gov.au/def/nrm/5157de5b-e6ee-5843-8063-ba07a5a7e9d2>
-            <https://linked.data.gov.au/def/nrm/e3a4c141-a85e-58cc-bf8c-66c35d27f44f>
             <https://linked.data.gov.au/def/nrm/aa52280b-a63f-5a6d-b3bd-6045a379df00>
             <https://linked.data.gov.au/def/nrm/b4036db0-9852-5772-bff5-4dffccc829a0>
+            <https://linked.data.gov.au/def/nrm/5157de5b-e6ee-5843-8063-ba07a5a7e9d2>
+            <https://linked.data.gov.au/def/nrm/454dd8f1-00c8-4c22-9705-9d1f9c0e293d>
+            <https://linked.data.gov.au/def/nrm/4230d984-61df-459a-b36f-2b053b881c2d>
+            <https://linked.data.gov.au/def/nrm/f2abdf62-3f31-5932-ac6f-3e72f59ad44a>
         ) ;
     sh:message "The value of `rdf:value` _MUST_ exist in the Voucher specimen types controlled vocabulary." ;
     sh:name "Result value" ;


### PR DESCRIPTION
This PR updated LUTs for `voucher specimen type` in Opportune.